### PR TITLE
Fix CSP violations — move inline styles and script to external files

### DIFF
--- a/breach-timeline.css
+++ b/breach-timeline.css
@@ -1,0 +1,284 @@
+.kc-page {
+  --bt-red:  #ef4444;
+  --bt-mono: 'JetBrains Mono', ui-monospace, 'Cascadia Code', Menlo, Consolas, monospace;
+  --bt-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+/* Hero */
+    .kc-hero {
+      background: #0a0f1e;
+      color: #f1f5f9;
+      padding: 3.5rem 1.5rem 3rem;
+      text-align: center;
+      position: relative;
+      overflow: hidden;
+    }
+    .kc-hero::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background:
+        radial-gradient(ellipse 60% 40% at 20% 50%, rgba(239,68,68,.12) 0%, transparent 70%),
+        radial-gradient(ellipse 50% 60% at 80% 30%, rgba(14,165,233,.10) 0%, transparent 70%);
+      pointer-events: none;
+    }
+    .kc-hero h1 {
+      font-family: var(--bt-mono);
+      font-size: clamp(1.4rem, 4vw, 2.4rem);
+      font-weight: 700;
+      margin: 0 0 .75rem;
+      position: relative;
+    }
+    .kc-hero h1 span { color: var(--bt-red); }
+    .kc-hero p {
+      max-width: 620px;
+      margin: 0 auto 1.5rem;
+      color: #94a3b8;
+      font-size: 1rem;
+      line-height: 1.7;
+      position: relative;
+    }
+    .hero-chips { display: flex; gap: .6rem; justify-content: center; flex-wrap: wrap; position: relative; }
+    .hero-chip { font-family: var(--bt-mono); font-size: .7rem; padding: .3rem .75rem; border-radius: 4px; border: 1px solid; font-weight: 600; }
+    .chip-mitre { border-color: #f97316; color: #fb923c; background: rgba(249,115,22,.1); }
+    .chip-steps { border-color: #22d3ee; color: #22d3ee; background: rgba(34,211,238,.08); }
+    .chip-src   { border-color: #a78bfa; color: #c4b5fd; background: rgba(167,139,250,.08); }
+
+    /* Tabs */
+    .incident-tabs {
+      position: sticky; top: 0; z-index: 40;
+      background: #0f172a; border-bottom: 1px solid #1e293b;
+      display: flex; overflow-x: auto; scrollbar-width: none;
+    }
+    .incident-tabs::-webkit-scrollbar { display: none; }
+    .itab {
+      flex-shrink: 0; padding: .9rem 1.4rem; font-size: .82rem; font-weight: 600;
+      color: #64748b; cursor: pointer; border-bottom: 3px solid transparent;
+      transition: color .2s, border-color .2s; white-space: nowrap;
+      background: none; border-top: none; border-left: none; border-right: none;
+      font-family: var(--bt-sans);
+    }
+    .itab:hover { color: #94a3b8; }
+    .itab.active { color: #f1f5f9; border-bottom-color: var(--bt-red); }
+    .itab-prov {
+      display: inline-block; margin-left: .4rem; font-size: .63rem;
+      padding: .1rem .4rem; border-radius: 3px; font-family: var(--bt-mono); font-weight: 700;
+    }
+    .prov-aws   { background: rgba(251,191,36,.15); color: #fbbf24; }
+    .prov-azure { background: rgba(96,165,250,.15);  color: #60a5fa; }
+
+    /* Main */
+    .kc-main { background: #080d18; min-height: 60vh; padding: 0 0 4rem; }
+    .incident-panel { display: none; }
+    .incident-panel.active { display: block; }
+
+    /* Incident header */
+    .inc-header {
+      background: #0f172a; border-bottom: 1px solid #1e293b;
+      padding: 2rem 1.5rem 1.5rem; max-width: 960px; margin: 0 auto;
+    }
+    .inc-meta { display: flex; gap: .6rem; flex-wrap: wrap; margin-bottom: .85rem; align-items: center; }
+    .inc-year { font-family: var(--bt-mono); font-size: .75rem; font-weight: 700; color: #64748b; }
+    .sev-badge { font-family: var(--bt-mono); font-size: .68rem; font-weight: 700; text-transform: uppercase; padding: .2rem .6rem; border-radius: 3px; }
+    .sev-critical { background: rgba(239,68,68,.15); color: var(--bt-red); border: 1px solid rgba(239,68,68,.3); }
+    .prov-tag { font-family: var(--bt-mono); font-size: .68rem; font-weight: 700; padding: .2rem .6rem; border-radius: 3px; }
+    .inc-title { font-family: var(--bt-mono); font-size: clamp(1rem, 2.5vw, 1.45rem); font-weight: 700; color: #f1f5f9; margin: 0 0 .75rem; line-height: 1.35; }
+    .inc-summary { font-size: .91rem; color: #94a3b8; line-height: 1.7; max-width: 720px; margin-bottom: 1rem; }
+    .inc-stats { display: flex; gap: 1.5rem; flex-wrap: wrap; }
+    .inc-stat { font-size: .8rem; color: #64748b; }
+    .inc-stat strong { color: #cbd5e1; }
+    .pm-link { display: inline-flex; align-items: center; gap: .3rem; font-size: .78rem; font-family: var(--bt-mono); color: #38bdf8; text-decoration: none; margin-top: .75rem; margin-right: .75rem; }
+    .pm-link:hover { text-decoration: underline; }
+
+    /* Kill chain */
+    .kill-chain { max-width: 960px; margin: 0 auto; padding: 2rem 1.5rem; position: relative; }
+    .kill-chain::before {
+      content: ''; position: absolute;
+      left: calc(1.5rem + 19px); top: 2rem; bottom: 4rem;
+      width: 1px;
+      background: linear-gradient(to bottom, #ef4444 0%, #7c3aed 50%, #0ea5e9 100%);
+      opacity: .25;
+    }
+    @media (min-width: 640px) { .kill-chain::before { left: calc(1.5rem + 23px); } }
+
+    /* Phase label */
+    .phase-lbl {
+      font-family: var(--bt-mono); font-size: .63rem; font-weight: 700;
+      text-transform: uppercase; letter-spacing: .12em; color: #475569;
+      margin: 1.75rem 0 .7rem 3.5rem;
+      display: flex; align-items: center; gap: .75rem;
+    }
+    @media (min-width: 640px) { .phase-lbl { margin-left: 4.4rem; } }
+    .phase-lbl::after { content: ''; flex: 1; height: 1px; background: #1e293b; }
+    .ph-recon   { color: #f59e0b; }
+    .ph-init    { color: #ef4444; }
+    .ph-exec    { color: #f97316; }
+    .ph-cred    { color: #fde047; }
+    .ph-priv    { color: #a855f7; }
+    .ph-persist { color: #6366f1; }
+    .ph-exfil   { color: #22d3ee; }
+    .ph-impact  { color: #10b981; }
+    .ph-disco   { color: #94a3b8; }
+
+    /* Step */
+    .kc-step { display: flex; gap: 1rem; margin-bottom: .9rem; animation: slideIn .3s ease both; }
+    @keyframes slideIn { from { opacity:0; transform: translateX(-8px); } to { opacity:1; transform: none; } }
+    .kc-step:nth-child(2) { animation-delay:.05s; }
+    .kc-step:nth-child(3) { animation-delay:.10s; }
+    .kc-step:nth-child(4) { animation-delay:.15s; }
+    .kc-step:nth-child(5) { animation-delay:.20s; }
+    .kc-step:nth-child(6) { animation-delay:.25s; }
+    .kc-step:nth-child(7) { animation-delay:.30s; }
+
+    .step-num {
+      flex-shrink: 0; width: 38px; height: 38px; border-radius: 50%;
+      border: 1.5px solid #334155; background: #0f172a;
+      display: flex; align-items: center; justify-content: center;
+      font-family: var(--bt-mono); font-size: .72rem; font-weight: 700;
+      color: #475569; position: relative; z-index: 1; margin-top: .1rem;
+    }
+    .step-r .step-num  { border-color: #ef4444; color: #ef4444; background: rgba(239,68,68,.1); }
+    .step-o .step-num  { border-color: #f97316; color: #f97316; background: rgba(249,115,22,.1); }
+    .step-y .step-num  { border-color: #f59e0b; color: #f59e0b; background: rgba(245,158,11,.1); }
+    .step-p .step-num  { border-color: #a855f7; color: #a855f7; background: rgba(168,85,247,.1); }
+    .step-b .step-num  { border-color: #6366f1; color: #6366f1; background: rgba(99,102,241,.1); }
+    .step-c .step-num  { border-color: #22d3ee; color: #22d3ee; background: rgba(34,211,238,.1); }
+    .step-g .step-num  { border-color: #10b981; color: #10b981; background: rgba(16,185,129,.1); }
+
+    .step-body {
+      flex: 1; background: #0d1424; border: 1px solid #1e293b;
+      border-radius: 8px; padding: .95rem 1.2rem; transition: border-color .2s;
+    }
+    .step-body:hover { border-color: #334155; }
+
+    .step-hdr { display: flex; gap: .5rem; align-items: flex-start; flex-wrap: wrap; margin-bottom: .45rem; }
+    .step-title { font-size: .92rem; font-weight: 700; color: #e2e8f0; flex: 1; min-width: 160px; }
+
+    .mt {
+      font-family: var(--bt-mono); font-size: .63rem; font-weight: 700;
+      padding: .2rem .52rem; border-radius: 3px; white-space: nowrap;
+      text-decoration: none; transition: opacity .15s;
+    }
+    .mt:hover { opacity: .75; text-decoration: underline; }
+    .mt-ta { background: rgba(249,115,22,.15); color: #fb923c; border: 1px solid rgba(249,115,22,.3); }
+    .mt-ex { background: rgba(239,68,68,.15);  color: #f87171; border: 1px solid rgba(239,68,68,.3); }
+    .mt-pe { background: rgba(168,85,247,.15); color: #c084fc; border: 1px solid rgba(168,85,247,.3); }
+    .mt-de { background: rgba(99,102,241,.15); color: #a5b4fc; border: 1px solid rgba(99,102,241,.3); }
+    .mt-ca { background: rgba(234,179,8,.15);  color: #fde047; border: 1px solid rgba(234,179,8,.3); }
+    .mt-di { background: rgba(20,184,166,.15); color: #5eead4; border: 1px solid rgba(20,184,166,.3); }
+    .mt-lm { background: rgba(59,130,246,.15); color: #93c5fd; border: 1px solid rgba(59,130,246,.3); }
+    .mt-co { background: rgba(16,185,129,.15); color: #6ee7b7; border: 1px solid rgba(16,185,129,.3); }
+    .mt-ef { background: rgba(34,211,238,.15); color: #67e8f9; border: 1px solid rgba(34,211,238,.3); }
+    .mt-p2 { background: rgba(168,85,247,.15); color: #c084fc; border: 1px solid rgba(168,85,247,.3); }
+
+    .step-desc { font-size: .86rem; color: #94a3b8; line-height: 1.65; margin-bottom: .55rem; }
+    .step-code {
+      font-family: var(--bt-mono); font-size: .73rem;
+      background: #070b14; border: 1px solid #1e293b;
+      border-radius: 5px; padding: .55rem .8rem;
+      color: #64748b; margin-bottom: .55rem; line-height: 1.6;
+    }
+    .step-code .hl { color: #f59e0b; }
+    .step-tags { display: flex; gap: .35rem; flex-wrap: wrap; }
+    .stag { font-size: .66rem; padding: .13rem .48rem; border-radius: 3px; background: #1e293b; color: #64748b; font-family: var(--bt-mono); }
+
+    /* Defender box */
+    .def-box { margin-top: 2rem; background: #0a1628; border: 1px solid #1e3a5f; border-left: 3px solid #38bdf8; border-radius: 0 8px 8px 0; padding: 1.2rem 1.4rem; }
+    .def-box h3 { font-family: var(--bt-mono); font-size: .75rem; font-weight: 700; color: #38bdf8; text-transform: uppercase; letter-spacing: .1em; margin: 0 0 .7rem; }
+    .def-items { display: flex; flex-direction: column; gap: .45rem; }
+    .def-item { display: flex; gap: .7rem; font-size: .83rem; color: #94a3b8; line-height: 1.55; }
+    .def-item::before { content: '→'; color: #38bdf8; flex-shrink: 0; font-family: var(--bt-mono); font-weight: 700; margin-top: .05rem; }
+
+    /* Sources */
+    .src-box { margin-top: 1.4rem; padding: .9rem 1.1rem; background: #0a0f1e; border: 1px solid #1e293b; border-radius: 8px; }
+    .src-box h4 { font-family: var(--bt-mono); font-size: .65rem; font-weight: 700; color: #475569; text-transform: uppercase; letter-spacing: .1em; margin: 0 0 .55rem; }
+    .src-links { display: flex; gap: .45rem; flex-wrap: wrap; }
+    .src-link { font-size: .73rem; color: #38bdf8; text-decoration: none; font-family: var(--bt-mono); padding: .18rem .52rem; border: 1px solid #1e3a5f; border-radius: 3px; transition: background .15s; }
+    .src-link:hover { background: rgba(56,189,248,.08); }
+
+    /* CTA */
+    .contribute-cta { max-width: 960px; margin: 2.5rem auto 0; padding: 1.4rem; background: #0d1424; border: 1px dashed #1e293b; border-radius: 8px; text-align: center; }
+    .contribute-cta h3 { font-family: var(--bt-mono); color: #e2e8f0; font-size: .9rem; margin: 0 0 .35rem; }
+    .contribute-cta p { color: #64748b; font-size: .83rem; margin: 0 0 .9rem; }
+    .btn-mono { display: inline-flex; align-items: center; gap: .4rem; font-family: var(--bt-mono); font-size: .78rem; font-weight: 700; padding: .5rem 1rem; background: rgba(239,68,68,.1); border: 1px solid rgba(239,68,68,.35); color: #f87171; border-radius: 5px; text-decoration: none; transition: background .15s; }
+    .btn-mono:hover { background: rgba(239,68,68,.2); }
+
+    /* Force dark theme baseline — overrides any site-level light defaults */
+    .kc-hero { background: #0a0f1e; }
+    .incident-tabs { background: #0f172a; border-color: #1e293b; }
+    .kc-main { background: #080d18; }
+    .inc-header { background: #0f172a; border-color: #1e293b; }
+    .inc-title { color: #f1f5f9; }
+    .inc-summary { color: #94a3b8; }
+    .inc-stat { color: #64748b; }
+    .inc-stat strong { color: #cbd5e1; }
+    .step-body { background: #0d1424; border-color: #1e293b; }
+    .step-title { color: #e2e8f0; }
+    .step-desc { color: #94a3b8; }
+    .step-code { background: #070b14; border-color: #1e293b; color: #64748b; }
+    .step-code .hl { color: #f59e0b; }
+    .stag { background: #1e293b; color: #64748b; }
+    .phase-lbl::after { background: #1e293b; }
+    .def-box { background: #0a1628; border-color: #1e3a5f; }
+    .def-box h3 { color: #38bdf8; }
+    .def-item { color: #94a3b8; }
+    .def-item::before { color: #38bdf8; }
+    .src-box { background: #0a0f1e; border-color: #1e293b; }
+    .src-box h4 { color: #475569; }
+    .contribute-cta { background: #0d1424; border-color: #1e293b; }
+    .contribute-cta h3 { color: #e2e8f0; }
+    .contribute-cta p { color: #64748b; }
+    .itab { color: #64748b; }
+    .itab:hover { color: #94a3b8; }
+    .itab.active { color: #f1f5f9; }
+
+    /* Light mode overrides — triggered by data-theme="light" on <html> */
+    :root[data-theme="light"] .kc-hero { background: #0f172a; }
+    :root[data-theme="light"] .incident-tabs { background: #1e293b; border-color: #334155; }
+    :root[data-theme="light"] .kc-main { background: #f8fafc; }
+    :root[data-theme="light"] .inc-header { background: #fff; border-color: #e2e8f0; }
+    :root[data-theme="light"] .inc-title { color: #0f172a; }
+    :root[data-theme="light"] .inc-summary { color: #475569; }
+    :root[data-theme="light"] .inc-stat { color: #64748b; }
+    :root[data-theme="light"] .inc-stat strong { color: #1e293b; }
+    :root[data-theme="light"] .step-body { background: #fff; border-color: #e2e8f0; }
+    :root[data-theme="light"] .step-title { color: #0f172a; }
+    :root[data-theme="light"] .step-desc { color: #475569; }
+    :root[data-theme="light"] .step-code { background: #f1f5f9; border-color: #e2e8f0; color: #475569; }
+    :root[data-theme="light"] .step-code .hl { color: #b45309; }
+    :root[data-theme="light"] .stag { background: #f1f5f9; color: #64748b; }
+    :root[data-theme="light"] .kill-chain::before { opacity: .4; }
+    :root[data-theme="light"] .phase-lbl::after { background: #e2e8f0; }
+    :root[data-theme="light"] .def-box { background: #eff6ff; border-color: #93c5fd; border-left-color: #3b82f6; }
+    :root[data-theme="light"] .def-box h3 { color: #1d4ed8; }
+    :root[data-theme="light"] .def-item { color: #334155; }
+    :root[data-theme="light"] .def-item::before { color: #3b82f6; }
+    :root[data-theme="light"] .src-box { background: #f8fafc; border-color: #e2e8f0; }
+    :root[data-theme="light"] .src-box h4 { color: #94a3b8; }
+    :root[data-theme="light"] .contribute-cta { background: #fff; border-color: #e2e8f0; }
+    :root[data-theme="light"] .contribute-cta h3 { color: #0f172a; }
+    :root[data-theme="light"] .contribute-cta p { color: #64748b; }
+    :root[data-theme="light"] .itab { color: #94a3b8; }
+    :root[data-theme="light"] .itab:hover { color: #475569; }
+    :root[data-theme="light"] .itab.active { color: #0f172a; }
+    :root[data-theme="light"] .step-num { border-color: #cbd5e1; background: #f8fafc; color: #94a3b8; }
+    :root[data-theme="light"] .step-r .step-num { background: #fef2f2; }
+    :root[data-theme="light"] .step-o .step-num { background: #fff7ed; }
+    :root[data-theme="light"] .step-p .step-num { background: #faf5ff; }
+    :root[data-theme="light"] .step-b .step-num { background: #eef2ff; }
+    :root[data-theme="light"] .step-c .step-num { background: #ecfeff; }
+    :root[data-theme="light"] .step-g .step-num { background: #f0fdf4; }
+    :root[data-theme="light"] .step-y .step-num { background: #fefce8; }
+/* Provider tag colour variants */
+.prov-purple { background: rgba(168,85,247,.15); color: #c084fc; }
+.prov-green  { background: rgba(34,197,94,.15);  color: #4ade80; }
+.prov-blue   { background: rgba(96,165,250,.15);  color: #60a5fa; }
+
+/* Mitnick community note banner */
+.mitnick-note {
+  margin-top: 1rem; padding: .75rem 1rem;
+  background: rgba(168,85,247,.08);
+  border: 1px solid rgba(168,85,247,.25);
+  border-radius: 6px; font-size: .8rem;
+  color: #c084fc; font-family: var(--bt-mono);
+}
+.mitnick-note a { color: #c084fc; }

--- a/breach-timeline.html
+++ b/breach-timeline.html
@@ -6,257 +6,8 @@
   <title>Cloud Breach Kill Chains – CSOH</title>
   <meta name="description" content="Step-by-step attack kill chains for major cloud security breaches, mapped to MITRE ATT&CK Cloud techniques. A learning resource for cloud security professionals." />
   <link rel="icon" href="favicon.png" type="image/png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=c4a4628a" integrity="sha384-rOUXa/2ZSzMIatsy4p9hJETbFabHMotwz4pkC3NH9iq0SfBJOThn0NmgNm2Wdi2Q" />
-  <style>
-    :root {
-      --red: #ef4444;
-      --mono: 'JetBrains Mono', monospace;
-      --sans: 'DM Sans', sans-serif;
-    }
-    body { font-family: var(--sans); }
-
-    /* Hero */
-    .kc-hero {
-      background: #0a0f1e;
-      color: #f1f5f9;
-      padding: 3.5rem 1.5rem 3rem;
-      text-align: center;
-      position: relative;
-      overflow: hidden;
-    }
-    .kc-hero::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background:
-        radial-gradient(ellipse 60% 40% at 20% 50%, rgba(239,68,68,.12) 0%, transparent 70%),
-        radial-gradient(ellipse 50% 60% at 80% 30%, rgba(14,165,233,.10) 0%, transparent 70%);
-      pointer-events: none;
-    }
-    .kc-hero h1 {
-      font-family: var(--mono);
-      font-size: clamp(1.4rem, 4vw, 2.4rem);
-      font-weight: 700;
-      margin: 0 0 .75rem;
-      position: relative;
-    }
-    .kc-hero h1 span { color: var(--red); }
-    .kc-hero p {
-      max-width: 620px;
-      margin: 0 auto 1.5rem;
-      color: #94a3b8;
-      font-size: 1rem;
-      line-height: 1.7;
-      position: relative;
-    }
-    .hero-chips { display: flex; gap: .6rem; justify-content: center; flex-wrap: wrap; position: relative; }
-    .hero-chip { font-family: var(--mono); font-size: .7rem; padding: .3rem .75rem; border-radius: 4px; border: 1px solid; font-weight: 600; }
-    .chip-mitre { border-color: #f97316; color: #fb923c; background: rgba(249,115,22,.1); }
-    .chip-steps { border-color: #22d3ee; color: #22d3ee; background: rgba(34,211,238,.08); }
-    .chip-src   { border-color: #a78bfa; color: #c4b5fd; background: rgba(167,139,250,.08); }
-
-    /* Tabs */
-    .incident-tabs {
-      position: sticky; top: 0; z-index: 40;
-      background: #0f172a; border-bottom: 1px solid #1e293b;
-      display: flex; overflow-x: auto; scrollbar-width: none;
-    }
-    .incident-tabs::-webkit-scrollbar { display: none; }
-    .itab {
-      flex-shrink: 0; padding: .9rem 1.4rem; font-size: .82rem; font-weight: 600;
-      color: #64748b; cursor: pointer; border-bottom: 3px solid transparent;
-      transition: color .2s, border-color .2s; white-space: nowrap;
-      background: none; border-top: none; border-left: none; border-right: none;
-      font-family: var(--sans);
-    }
-    .itab:hover { color: #94a3b8; }
-    .itab.active { color: #f1f5f9; border-bottom-color: var(--red); }
-    .itab-prov {
-      display: inline-block; margin-left: .4rem; font-size: .63rem;
-      padding: .1rem .4rem; border-radius: 3px; font-family: var(--mono); font-weight: 700;
-    }
-    .prov-aws   { background: rgba(251,191,36,.15); color: #fbbf24; }
-    .prov-azure { background: rgba(96,165,250,.15);  color: #60a5fa; }
-
-    /* Main */
-    .kc-main { background: #080d18; min-height: 60vh; padding: 0 0 4rem; }
-    .incident-panel { display: none; }
-    .incident-panel.active { display: block; }
-
-    /* Incident header */
-    .inc-header {
-      background: #0f172a; border-bottom: 1px solid #1e293b;
-      padding: 2rem 1.5rem 1.5rem; max-width: 960px; margin: 0 auto;
-    }
-    .inc-meta { display: flex; gap: .6rem; flex-wrap: wrap; margin-bottom: .85rem; align-items: center; }
-    .inc-year { font-family: var(--mono); font-size: .75rem; font-weight: 700; color: #64748b; }
-    .sev-badge { font-family: var(--mono); font-size: .68rem; font-weight: 700; text-transform: uppercase; padding: .2rem .6rem; border-radius: 3px; }
-    .sev-critical { background: rgba(239,68,68,.15); color: var(--red); border: 1px solid rgba(239,68,68,.3); }
-    .prov-tag { font-family: var(--mono); font-size: .68rem; font-weight: 700; padding: .2rem .6rem; border-radius: 3px; }
-    .inc-title { font-family: var(--mono); font-size: clamp(1rem, 2.5vw, 1.45rem); font-weight: 700; color: #f1f5f9; margin: 0 0 .75rem; line-height: 1.35; }
-    .inc-summary { font-size: .91rem; color: #94a3b8; line-height: 1.7; max-width: 720px; margin-bottom: 1rem; }
-    .inc-stats { display: flex; gap: 1.5rem; flex-wrap: wrap; }
-    .inc-stat { font-size: .8rem; color: #64748b; }
-    .inc-stat strong { color: #cbd5e1; }
-    .pm-link { display: inline-flex; align-items: center; gap: .3rem; font-size: .78rem; font-family: var(--mono); color: #38bdf8; text-decoration: none; margin-top: .75rem; margin-right: .75rem; }
-    .pm-link:hover { text-decoration: underline; }
-
-    /* Kill chain */
-    .kill-chain { max-width: 960px; margin: 0 auto; padding: 2rem 1.5rem; position: relative; }
-    .kill-chain::before {
-      content: ''; position: absolute;
-      left: calc(1.5rem + 19px); top: 2rem; bottom: 4rem;
-      width: 1px;
-      background: linear-gradient(to bottom, #ef4444 0%, #7c3aed 50%, #0ea5e9 100%);
-      opacity: .25;
-    }
-    @media (min-width: 640px) { .kill-chain::before { left: calc(1.5rem + 23px); } }
-
-    /* Phase label */
-    .phase-lbl {
-      font-family: var(--mono); font-size: .63rem; font-weight: 700;
-      text-transform: uppercase; letter-spacing: .12em; color: #475569;
-      margin: 1.75rem 0 .7rem 3.5rem;
-      display: flex; align-items: center; gap: .75rem;
-    }
-    @media (min-width: 640px) { .phase-lbl { margin-left: 4.4rem; } }
-    .phase-lbl::after { content: ''; flex: 1; height: 1px; background: #1e293b; }
-    .ph-recon   { color: #f59e0b; }
-    .ph-init    { color: #ef4444; }
-    .ph-exec    { color: #f97316; }
-    .ph-cred    { color: #fde047; }
-    .ph-priv    { color: #a855f7; }
-    .ph-persist { color: #6366f1; }
-    .ph-exfil   { color: #22d3ee; }
-    .ph-impact  { color: #10b981; }
-    .ph-disco   { color: #94a3b8; }
-
-    /* Step */
-    .kc-step { display: flex; gap: 1rem; margin-bottom: .9rem; animation: slideIn .3s ease both; }
-    @keyframes slideIn { from { opacity:0; transform: translateX(-8px); } to { opacity:1; transform: none; } }
-    .kc-step:nth-child(2) { animation-delay:.05s; }
-    .kc-step:nth-child(3) { animation-delay:.10s; }
-    .kc-step:nth-child(4) { animation-delay:.15s; }
-    .kc-step:nth-child(5) { animation-delay:.20s; }
-    .kc-step:nth-child(6) { animation-delay:.25s; }
-    .kc-step:nth-child(7) { animation-delay:.30s; }
-
-    .step-num {
-      flex-shrink: 0; width: 38px; height: 38px; border-radius: 50%;
-      border: 1.5px solid #334155; background: #0f172a;
-      display: flex; align-items: center; justify-content: center;
-      font-family: var(--mono); font-size: .72rem; font-weight: 700;
-      color: #475569; position: relative; z-index: 1; margin-top: .1rem;
-    }
-    .step-r .step-num  { border-color: #ef4444; color: #ef4444; background: rgba(239,68,68,.1); }
-    .step-o .step-num  { border-color: #f97316; color: #f97316; background: rgba(249,115,22,.1); }
-    .step-y .step-num  { border-color: #f59e0b; color: #f59e0b; background: rgba(245,158,11,.1); }
-    .step-p .step-num  { border-color: #a855f7; color: #a855f7; background: rgba(168,85,247,.1); }
-    .step-b .step-num  { border-color: #6366f1; color: #6366f1; background: rgba(99,102,241,.1); }
-    .step-c .step-num  { border-color: #22d3ee; color: #22d3ee; background: rgba(34,211,238,.1); }
-    .step-g .step-num  { border-color: #10b981; color: #10b981; background: rgba(16,185,129,.1); }
-
-    .step-body {
-      flex: 1; background: #0d1424; border: 1px solid #1e293b;
-      border-radius: 8px; padding: .95rem 1.2rem; transition: border-color .2s;
-    }
-    .step-body:hover { border-color: #334155; }
-
-    .step-hdr { display: flex; gap: .5rem; align-items: flex-start; flex-wrap: wrap; margin-bottom: .45rem; }
-    .step-title { font-size: .92rem; font-weight: 700; color: #e2e8f0; flex: 1; min-width: 160px; }
-
-    .mt {
-      font-family: var(--mono); font-size: .63rem; font-weight: 700;
-      padding: .2rem .52rem; border-radius: 3px; white-space: nowrap;
-      text-decoration: none; transition: opacity .15s;
-    }
-    .mt:hover { opacity: .75; text-decoration: underline; }
-    .mt-ta { background: rgba(249,115,22,.15); color: #fb923c; border: 1px solid rgba(249,115,22,.3); }
-    .mt-ex { background: rgba(239,68,68,.15);  color: #f87171; border: 1px solid rgba(239,68,68,.3); }
-    .mt-pe { background: rgba(168,85,247,.15); color: #c084fc; border: 1px solid rgba(168,85,247,.3); }
-    .mt-de { background: rgba(99,102,241,.15); color: #a5b4fc; border: 1px solid rgba(99,102,241,.3); }
-    .mt-ca { background: rgba(234,179,8,.15);  color: #fde047; border: 1px solid rgba(234,179,8,.3); }
-    .mt-di { background: rgba(20,184,166,.15); color: #5eead4; border: 1px solid rgba(20,184,166,.3); }
-    .mt-lm { background: rgba(59,130,246,.15); color: #93c5fd; border: 1px solid rgba(59,130,246,.3); }
-    .mt-co { background: rgba(16,185,129,.15); color: #6ee7b7; border: 1px solid rgba(16,185,129,.3); }
-    .mt-ef { background: rgba(34,211,238,.15); color: #67e8f9; border: 1px solid rgba(34,211,238,.3); }
-    .mt-p2 { background: rgba(168,85,247,.15); color: #c084fc; border: 1px solid rgba(168,85,247,.3); }
-
-    .step-desc { font-size: .86rem; color: #94a3b8; line-height: 1.65; margin-bottom: .55rem; }
-    .step-code {
-      font-family: var(--mono); font-size: .73rem;
-      background: #070b14; border: 1px solid #1e293b;
-      border-radius: 5px; padding: .55rem .8rem;
-      color: #64748b; margin-bottom: .55rem; line-height: 1.6;
-    }
-    .step-code .hl { color: #f59e0b; }
-    .step-tags { display: flex; gap: .35rem; flex-wrap: wrap; }
-    .stag { font-size: .66rem; padding: .13rem .48rem; border-radius: 3px; background: #1e293b; color: #64748b; font-family: var(--mono); }
-
-    /* Defender box */
-    .def-box { margin-top: 2rem; background: #0a1628; border: 1px solid #1e3a5f; border-left: 3px solid #38bdf8; border-radius: 0 8px 8px 0; padding: 1.2rem 1.4rem; }
-    .def-box h3 { font-family: var(--mono); font-size: .75rem; font-weight: 700; color: #38bdf8; text-transform: uppercase; letter-spacing: .1em; margin: 0 0 .7rem; }
-    .def-items { display: flex; flex-direction: column; gap: .45rem; }
-    .def-item { display: flex; gap: .7rem; font-size: .83rem; color: #94a3b8; line-height: 1.55; }
-    .def-item::before { content: '→'; color: #38bdf8; flex-shrink: 0; font-family: var(--mono); font-weight: 700; margin-top: .05rem; }
-
-    /* Sources */
-    .src-box { margin-top: 1.4rem; padding: .9rem 1.1rem; background: #0a0f1e; border: 1px solid #1e293b; border-radius: 8px; }
-    .src-box h4 { font-family: var(--mono); font-size: .65rem; font-weight: 700; color: #475569; text-transform: uppercase; letter-spacing: .1em; margin: 0 0 .55rem; }
-    .src-links { display: flex; gap: .45rem; flex-wrap: wrap; }
-    .src-link { font-size: .73rem; color: #38bdf8; text-decoration: none; font-family: var(--mono); padding: .18rem .52rem; border: 1px solid #1e3a5f; border-radius: 3px; transition: background .15s; }
-    .src-link:hover { background: rgba(56,189,248,.08); }
-
-    /* CTA */
-    .contribute-cta { max-width: 960px; margin: 2.5rem auto 0; padding: 1.4rem; background: #0d1424; border: 1px dashed #1e293b; border-radius: 8px; text-align: center; }
-    .contribute-cta h3 { font-family: var(--mono); color: #e2e8f0; font-size: .9rem; margin: 0 0 .35rem; }
-    .contribute-cta p { color: #64748b; font-size: .83rem; margin: 0 0 .9rem; }
-    .btn-mono { display: inline-flex; align-items: center; gap: .4rem; font-family: var(--mono); font-size: .78rem; font-weight: 700; padding: .5rem 1rem; background: rgba(239,68,68,.1); border: 1px solid rgba(239,68,68,.35); color: #f87171; border-radius: 5px; text-decoration: none; transition: background .15s; }
-    .btn-mono:hover { background: rgba(239,68,68,.2); }
-
-    /* Light mode overrides */
-    body:not(.dark) .kc-hero { background: #0f172a; }
-    body:not(.dark) .incident-tabs { background: #1e293b; border-color: #334155; }
-    body:not(.dark) .kc-main { background: #f8fafc; }
-    body:not(.dark) .inc-header { background: #fff; border-color: #e2e8f0; }
-    body:not(.dark) .inc-title { color: #0f172a; }
-    body:not(.dark) .inc-summary { color: #475569; }
-    body:not(.dark) .inc-stat { color: #64748b; }
-    body:not(.dark) .inc-stat strong { color: #1e293b; }
-    body:not(.dark) .step-body { background: #fff; border-color: #e2e8f0; }
-    body:not(.dark) .step-body:hover { border-color: #cbd5e1; }
-    body:not(.dark) .step-title { color: #0f172a; }
-    body:not(.dark) .step-desc { color: #475569; }
-    body:not(.dark) .step-code { background: #f1f5f9; border-color: #e2e8f0; color: #475569; }
-    body:not(.dark) .step-code .hl { color: #b45309; }
-    body:not(.dark) .stag { background: #f1f5f9; color: #64748b; }
-    body:not(.dark) .kill-chain::before { opacity: .4; }
-    body:not(.dark) .phase-lbl { color: #94a3b8; }
-    body:not(.dark) .phase-lbl::after { background: #e2e8f0; }
-    body:not(.dark) .def-box { background: #eff6ff; border-color: #93c5fd; border-left-color: #3b82f6; }
-    body:not(.dark) .def-box h3 { color: #1d4ed8; }
-    body:not(.dark) .def-item { color: #334155; }
-    body:not(.dark) .def-item::before { color: #3b82f6; }
-    body:not(.dark) .src-box { background: #f8fafc; border-color: #e2e8f0; }
-    body:not(.dark) .src-box h4 { color: #94a3b8; }
-    body:not(.dark) .contribute-cta { background: #fff; border-color: #e2e8f0; }
-    body:not(.dark) .contribute-cta h3 { color: #0f172a; }
-    body:not(.dark) .contribute-cta p { color: #64748b; }
-    body:not(.dark) .itab { color: #94a3b8; }
-    body:not(.dark) .itab:hover { color: #475569; }
-    body:not(.dark) .itab.active { color: #0f172a; }
-    body:not(.dark) .step-num { border-color: #cbd5e1; background: #f8fafc; color: #94a3b8; }
-    body:not(.dark) .step-r .step-num { background: #fef2f2; }
-    body:not(.dark) .step-o .step-num { background: #fff7ed; }
-    body:not(.dark) .step-p .step-num { background: #faf5ff; }
-    body:not(.dark) .step-b .step-num { background: #eef2ff; }
-    body:not(.dark) .step-c .step-num { background: #ecfeff; }
-    body:not(.dark) .step-g .step-num { background: #f0fdf4; }
-    body:not(.dark) .step-y .step-num { background: #fefce8; }
-  </style>
+  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="breach-timeline.css">
 </head>
 <body>
 
@@ -292,11 +43,11 @@
   <button class="itab" data-panel="storm-0558" data-year="2023" role="tab">Storm-0558 2023 <span class="itab-prov prov-azure">Azure</span></button>
   <button class="itab" data-panel="solarwinds" data-year="2020" role="tab">SolarWinds 2020 <span class="itab-prov prov-azure">Azure AD</span></button>
   <button class="itab" data-panel="ms-sas" data-year="2023" role="tab">Microsoft SAS Leak 2023 <span class="itab-prov prov-azure">Azure</span></button>
-  <button class="itab" data-panel="mitnick-novell" data-year="1994" role="tab">Mitnick / Novell 1994 <span class="itab-prov" style="background:rgba(168,85,247,.15);color:#c084fc;">On-Prem</span></button>
+  <button class="itab" data-panel="mitnick-novell" data-year="1994" role="tab">Mitnick / Novell 1994 <span class="itab-prov prov-purple">On-Prem</span></button>
   <button class="itab" data-panel="scattered-spider" data-year="2023" role="tab">Scattered Spider / MGM 2023 <span class="itab-prov prov-azure">Okta · Azure</span></button>
 </nav>
 
-<main class="kc-main">
+<main class="kc-main kc-page">
 
 <!-- ═══════════════ CAPITAL ONE ═══════════════ -->
 <div id="capital-one" class="incident-panel active" role="tabpanel">
@@ -455,7 +206,7 @@
       <span class="inc-year">September 15–16, 2022</span>
       <span class="sev-badge sev-critical">Critical</span>
       <span class="prov-tag prov-aws">AWS</span>
-      <span class="prov-tag" style="background:rgba(34,197,94,.15);color:#4ade80;font-family:var(--mono);font-size:.68rem;font-weight:700;padding:.2rem .6rem;border-radius:3px;">GCP</span>
+      <span class="prov-tag prov-green">GCP</span>
     </div>
     <h2 class="inc-title">Uber – Dark Web Creds → MFA Push Fatigue → Hardcoded PAM Secret → Full AWS/GCP Admin</h2>
     <p class="inc-summary">An 18-year-old attacker purchased an Uber contractor's VPN credentials from a dark web infostealer marketplace, then used MFA push-bombing combined with WhatsApp social engineering to bypass two-factor auth. Once inside the corporate network, they found a PowerShell script with hardcoded admin credentials for Thycotic — Uber's PAM system — unlocking full admin access to AWS, GCP, Slack, SentinelOne, HackerOne, and more within hours.</p>
@@ -1039,7 +790,7 @@
     <div class="inc-meta">
       <span class="inc-year">1993–1995 (fugitive period)</span>
       <span class="sev-badge sev-critical">Critical</span>
-      <span class="prov-tag" style="background:rgba(168,85,247,.15);color:#c084fc;font-family:var(--mono);font-size:.68rem;font-weight:700;padding:.2rem .6rem;border-radius:3px;">On-Premises / Dial-Up</span>
+      <span class="prov-tag prov-purple">On-Premises / Dial-Up</span>
     </div>
     <h2 class="inc-title">Kevin Mitnick / Novell – OSINT → Pretexting → Phone Social Engineering → Dial-Up Access → NetWare Source Code Theft</h2>
     <p class="inc-summary">While a fugitive living under a false identity in Denver, Kevin Mitnick — the FBI's most wanted hacker — targeted Novell's technical support staff using a technique he called pretexting. By impersonating a Novell employee using authentic corporate lingo, internal knowledge, and manufactured urgency, he convinced support staff to provide credentials and system access. He then used dial-up connections to extract proprietary NetWare source code. Shawn Nunley, a Novell support analyst at the time, was directly targeted by Mitnick and later became the FBI's star witness — before becoming one of Mitnick's closest friends. This entry is notable as a foundational case study in social engineering before the term existed in mainstream security.</p>
@@ -1052,8 +803,8 @@
     <a class="pm-link" href="https://www.wired.com/2002/02/mitnick-meets-his-pigeon/" target="_blank" rel="noopener">📄 Wired — Mitnick Meets His Pigeon (Shawn Nunley) ↗</a>
     <a class="pm-link" href="https://www.encyclopedia.com/law/law-magazines/kevin-mitnick-case-1999" target="_blank" rel="noopener">📄 Federal indictment details ↗</a>
     <a class="pm-link" href="https://www.cybereason.com/blog/malicious-life-podcast-kevin-mitnick-part-2" target="_blank" rel="noopener">📄 Malicious Life — Mitnick Part 2 ↗</a>
-    <div style="margin-top:1rem;padding:.75rem 1rem;background:rgba(168,85,247,.08);border:1px solid rgba(168,85,247,.25);border-radius:6px;font-size:.8rem;color:#c084fc;font-family:var(--mono);">
-      ℹ️ Shawn Nunley (CSOH founder) was Mitnick's target at Novell. For more on their remarkable story, read the <a href="https://csoh.org/kevin-mitnick.html" target="_blank" rel="noopener" style="color:#c084fc;">Kevin Mitnick — In Memoriam</a> tribute on this site.
+    <div class="mitnick-note">
+      ℹ️ Shawn Nunley (CSOH founder) was Mitnick's target at Novell. For more on their remarkable story, read the <a href="https://csoh.org/kevin-mitnick.html" target="_blank" rel="noopener">Kevin Mitnick — In Memoriam</a> tribute on this site.
     </div>
   </div>
 
@@ -1227,7 +978,7 @@
       <span class="inc-year">September 2023</span>
       <span class="sev-badge sev-critical">Critical</span>
       <span class="prov-tag prov-azure">Okta</span>
-      <span class="prov-tag" style="background:rgba(96,165,250,.15);color:#60a5fa;font-family:var(--mono);font-size:.68rem;font-weight:700;padding:.2rem .6rem;border-radius:3px;">Azure AD</span>
+      <span class="prov-tag prov-blue">Azure AD</span>
     </div>
     <h2 class="inc-title">Scattered Spider / MGM Resorts – LinkedIn OSINT → Vishing Help Desk → Okta Super Admin → Azure AD → 100 ESXi Servers Encrypted</h2>
     <p class="inc-summary">Scattered Spider (UNC3944) compromised MGM Resorts International in September 2023 using a single 10-minute phone call to the IT help desk. Attackers researched an MGM employee on LinkedIn, impersonated them to a help desk agent, obtained an MFA reset, and gained initial access. From there they escalated to Okta Super Administrator, claimed Azure AD tenant-level control, moved laterally across the network, and encrypted over 100 ESXi hypervisors using ALPHV/BlackCat ransomware — causing $100M in losses and a 10-day outage. The entire initial access chain required no technical exploit whatsoever.</p>
@@ -1485,29 +1236,7 @@
   </div>
 </footer>
 
-<script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="/main.js?v=d68d3a13" integrity="sha384-734NBbSGqixqcF2dyK7huLjxrr/nlAgPA91owd+nKDc83LahTK1SVLslSEZmv9Wg"></script>
-<script>
-  // Sort tabs by year extracted from their text content
-  const tabNav = document.querySelector('.incident-tabs');
-  const tabs = Array.from(tabNav.querySelectorAll('.itab'));
-
-  tabs.sort((a, b) => {
-    return parseInt(a.dataset.year || 0) - parseInt(b.dataset.year || 0);
-  });
-
-  // Re-append in sorted order
-  tabs.forEach(tab => tabNav.appendChild(tab));
-
-  // Tab click switching
-  tabs.forEach(tab => {
-    tab.addEventListener('click', () => {
-      document.querySelectorAll('.itab').forEach(t => t.classList.remove('active'));
-      document.querySelectorAll('.incident-panel').forEach(p => p.classList.remove('active'));
-      tab.classList.add('active');
-      const panel = document.getElementById(tab.dataset.panel);
-      if (panel) panel.classList.add('active');
-    });
-  });
-</script>
+<script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="main.js"></script>
+<script src="breach-timeline.js"></script>
 </body>
 </html>

--- a/breach-timeline.js
+++ b/breach-timeline.js
@@ -1,0 +1,21 @@
+// Sort tabs by year extracted from their text content
+  const tabNav = document.querySelector('.incident-tabs');
+  const tabs = Array.from(tabNav.querySelectorAll('.itab'));
+
+  tabs.sort((a, b) => {
+    return parseInt(a.dataset.year || 0) - parseInt(b.dataset.year || 0);
+  });
+
+  // Re-append in sorted order
+  tabs.forEach(tab => tabNav.appendChild(tab));
+
+  // Tab click switching
+  tabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll('.itab').forEach(t => t.classList.remove('active'));
+      document.querySelectorAll('.incident-panel').forEach(p => p.classList.remove('active'));
+      tab.classList.add('active');
+      const panel = document.getElementById(tab.dataset.panel);
+      if (panel) panel.classList.add('active');
+    });
+  });


### PR DESCRIPTION
The page was blocked by the site's CSP directives because styles and JavaScript were inline. This PR moves them to external files breach-timeline.css and breach-timeline.js which the CSP allows. No visual or functional changes.