### PR TITLE
Add kill chain: Promptware Kill Chain 2024–26

### DIFF
--- a/breach-timeline.html
+++ b/breach-timeline.html
@@ -113,6 +113,7 @@
   <button class="itab" data-panel="ms-sas" data-year="2023" role="tab">Microsoft SAS Leak 2023 <span class="itab-prov prov-azure">Azure</span></button>
   <button class="itab" data-panel="mitnick-novell" data-year="1994" role="tab">Mitnick / Novell 1994 <span class="itab-prov prov-purple">On-Prem</span></button>
   <button class="itab" data-panel="scattered-spider" data-year="2023" role="tab">Scattered Spider / MGM 2023 <span class="itab-prov prov-azure">Okta · Azure</span></button>
+  <button class="itab" data-panel="promptware-2024" data-year="2024" role="tab">Promptware Kill Chain 2024–26 <span class="itab-prov prov-green">AI · Cloud</span></button>
 </nav>
 
 <main class="kc-main kc-page" id="main-content">
@@ -1263,6 +1264,237 @@
         <a class="src-link" href="https://attack.mitre.org/techniques/T1078/004/" target="_blank" rel="noopener">MITRE T1078.004</a>
       </div>
     </div>
+  </div>
+</div>
+
+<!-- ═══════════════ PROMPTWARE KILL CHAIN ═══════════════ -->
+<div id="promptware-2024" class="incident-panel" role="tabpanel">
+  <div class="inc-header">
+    <div class="inc-meta">
+      <span class="inc-year">2024–2026</span>
+      <span class="sev-badge sev-critical">Critical</span>
+      <span class="prov-tag prov-green">AI · Cloud</span>
+    </div>
+    <h2 class="inc-title">Promptware – Indirect Prompt Injection → Context Poisoning → Persistence → C2 → Covert Camera Livestream</h2>
+    <p class="inc-summary">
+      Researchers demonstrated a complete seven-stage kill chain targeting cloud-connected AI assistants — from a malicious Google Calendar invite to covert Zoom video streaming, all triggered by the victim typing "thanks." Documented across 36 real-world incidents by Schneier, Nassi et al., the pattern — termed "promptware" — mirrors classical malware kill chains but executes entirely through the LLM prompt layer. C2 was confirmed in the ChatGPT ZombAI attack (Oct 2024) and the Microsoft Copilot Reprompt attack (Jan 2026, CVE-2026-24307), both patched after disclosure.
+    </p>
+    <div class="inc-stats">
+      <div class="inc-stat"><strong>36</strong> real-world incidents analysed</div>
+      <div class="inc-stat"><strong>21</strong> traverse 4+ kill chain stages</div>
+      <div class="inc-stat"><strong>73%</strong> of threat classes rated High–Critical</div>
+      <div class="inc-stat"><strong>Threat actor:</strong> Researchers (Nassi, Schneier et al.) / criminal adoption ongoing</div>
+    </div>
+    <a class="pm-link" href="https://arxiv.org/abs/2601.09625" target="_blank" rel="noopener">📄 arXiv:2601.09625 — The Promptware Kill Chain ↗</a>
+    <a class="pm-link" href="https://arxiv.org/abs/2508.12175" target="_blank" rel="noopener">📄 arXiv:2508.12175 — Invitation Is All You Need ↗</a>
+    <a class="pm-link" href="https://www.schneier.com/blog/archives/2026/02/the-promptware-kill-chain.html" target="_blank" rel="noopener">📄 Schneier on Security ↗</a>
+  </div>
+
+  <div class="kill-chain">
+
+    <div class="phase-lbl ph-init">⚡ Initial Access</div>
+    <div class="kc-step step-r">
+      <div class="step-num">01</div>
+      <div class="step-body">
+        <div class="step-hdr">
+          <div class="step-title">Malicious prompt injected into Google Calendar invite title — victim never sees it</div>
+          <a class="mt mt-ta" href="https://attack.mitre.org/techniques/T1566/" target="_blank" rel="noopener">T1566 – Phishing</a>
+        </div>
+        <p class="step-desc">
+          Attacker sends the target a Google Calendar meeting invitation with a malicious prompt embedded in the event title. When the victim asks Gemini "What are my meetings today?", the Google Calendar Agent retrieves the event — including the poisoned title — and feeds it directly into Gemini's active context. The victim never sees the raw title; they only see Gemini's natural-language response. This is indirect prompt injection: the attacker's instructions enter the LLM through a trusted, user-requested data retrieval, not through direct user input.
+        </p>
+        <div class="step-code">
+          <span class="hl">Delivery vector:</span> Google Calendar event title (shared workspace artifact)<br>
+          <span class="hl">Injection type:</span> Indirect — attacker content retrieved by the LLM on the victim's behalf<br>
+          <span class="hl">Why it works:</span> LLMs process all tokens — system prompts, user queries, retrieved data — as a single undifferentiated sequence; there is no code/data boundary
+        </div>
+        <div class="step-tags">
+          <span class="stag">Indirect Prompt Injection</span>
+          <span class="stag">Google Gemini</span>
+          <span class="stag">Google Calendar</span>
+          <span class="stag">T1566</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="phase-lbl ph-priv">🔼 Privilege Escalation — Safety Guardrail Bypass</div>
+    <div class="kc-step step-o">
+      <div class="step-num">02</div>
+      <div class="step-body">
+        <div class="step-hdr">
+          <div class="step-title">Delayed tool invocation defers execution until a benign user action — bypassing real-time guardrails</div>
+          <a class="mt mt-pe" href="https://attack.mitre.org/techniques/T1548/" target="_blank" rel="noopener">T1548 – Abuse Elevation Control Mechanism</a>
+        </div>
+        <p class="step-desc">
+          The injected prompt uses a technique called "delayed tool invocation": rather than triggering immediately (which would fire safety checks against the poison payload), the instructions stage the malicious action and wait for the user to perform a neutral follow-up — such as thanking Gemini. When the user types "thanks," Gemini re-enters a new inference step and the guardrails that evaluated the calendar retrieval do not re-evaluate the deferred instruction. The attacker's command executes with Gemini's full tool permissions.
+        </p>
+        <div class="step-code">
+          <span class="hl">Technique:</span> Delayed tool invocation — action staged at retrieval time, fired on next benign user turn<br>
+          <span class="hl">Guardrail failure:</span> Safety checks evaluated at prompt parse time, not at deferred execution time<br>
+          <span class="hl">Effect:</span> Attacker instructions treated as trusted system-level directives with full tool access
+        </div>
+        <div class="step-tags">
+          <span class="stag">Delayed Tool Invocation</span>
+          <span class="stag">Jailbreak</span>
+          <span class="stag">Guardrail Bypass</span>
+          <span class="stag">T1548</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="phase-lbl ph-recon">🔍 Reconnaissance — Enumerating Connected Services</div>
+    <div class="kc-step step-y">
+      <div class="step-num">03</div>
+      <div class="step-body">
+        <div class="step-hdr">
+          <div class="step-title">LLM queried for connected apps, available tools, and stored user memories — invisibly</div>
+          <a class="mt mt-di" href="https://attack.mitre.org/techniques/T1082/" target="_blank" rel="noopener">T1082 – System Information Discovery</a>
+        </div>
+        <p class="step-desc">
+          Following jailbreak, the injected prompt queries Gemini for its available tool inventory: connected agents (Google Calendar, Google Home, Gmail, Meet), installed mobile applications (Zoom, browser), and the user's stored memories and calendar data. Unlike classical malware reconnaissance — which precedes initial access — promptware recon occurs after context poisoning, because the LLM's tool inventory is only enumerable once the assistant is under attacker control. The enumeration results feed back into the attacker's context silently; nothing is displayed to the victim.
+        </p>
+        <div class="step-code">
+          <span class="hl">Information gathered:</span> Active agents (Calendar, Home, Meet), installed apps (Zoom, browser), user memories<br>
+          <span class="hl">Key difference from classical recon:</span> Occurs post-initial-access, not before — order is inverted<br>
+          <span class="hl">Visibility to victim:</span> None — responses go to model context, not rendered in the chat UI
+        </div>
+        <div class="step-tags">
+          <span class="stag">Tool Enumeration</span>
+          <span class="stag">Context Poisoning</span>
+          <span class="stag">Google Workspace</span>
+          <span class="stag">T1082</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="phase-lbl ph-persist">💾 Persistence — Memory Poisoning</div>
+    <div class="kc-step step-p">
+      <div class="step-num">04</div>
+      <div class="step-body">
+        <div class="step-hdr">
+          <div class="step-title">Malicious instructions written to long-term workspace memory — re-injected on every future session</div>
+          <a class="mt mt-p2" href="https://attack.mitre.org/techniques/T1546/" target="_blank" rel="noopener">T1546 – Event Triggered Execution</a>
+        </div>
+        <p class="step-desc">
+          Because the malicious prompt is embedded in a Google Calendar artifact, it persists in the workspace's long-term agent memory. Every subsequent session where Gemini accesses calendar data re-injects the attacker's instructions — turning a one-time event into a durable implant. The parallel ZombAI attack (ChatGPT, Oct 2024) demonstrated the same mechanism more explicitly: a prompt injection write to ChatGPT's persistent memory store caused the model to fetch C2 instructions from an attacker-controlled GitHub page at the start of every new conversation, indefinitely.
+        </p>
+        <div class="step-code">
+          <span class="hl">Calendar mechanism:</span> Poisoned event title re-retrieved on each calendar query across all future sessions<br>
+          <span class="hl">ZombAI mechanism:</span> Prompt injection → write to ChatGPT long-term memory → C2 instructions injected into every conversation<br>
+          <span class="hl">Defence gap:</span> No mechanism to audit, alert on, or require user consent for unexpected memory writes
+        </div>
+        <div class="step-tags">
+          <span class="stag">Memory Poisoning</span>
+          <span class="stag">ZombAI</span>
+          <span class="stag">ChatGPT Memory</span>
+          <span class="stag">Google Workspace</span>
+          <span class="stag">T1546</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="phase-lbl ph-exfil">📡 Command &amp; Control</div>
+    <div class="kc-step step-b">
+      <div class="step-num">05</div>
+      <div class="step-body">
+        <div class="step-hdr">
+          <div class="step-title">LLM beacons attacker-controlled server for updated instructions — C2 runs entirely through the prompt layer</div>
+          <a class="mt mt-co" href="https://attack.mitre.org/techniques/T1071/001/" target="_blank" rel="noopener">T1071.001 – Web Protocols</a>
+        </div>
+        <p class="step-desc">
+          ZombAI (Oct 2024): persisted memory instructs ChatGPT to fetch a GitHub Issues page at session start. The attacker posts updated instructions as sequential issues; a COUNTER increment in the payload defeats ChatGPT's page-caching so each beacon retrieves fresh commands. This was the first confirmed promptware-native C2 capability — the attacker remotely controlled the compromised ChatGPT instance with no conventional malware infrastructure. Reprompt (Jan 2026, CVE-2026-24307): a crafted Microsoft Copilot URL with a malicious <code>q</code> parameter caused Copilot to dynamically fetch follow-up instructions from an attacker server — exfiltrating session and profile data incrementally, with no limit on type or volume.
+        </p>
+        <div class="step-code">
+          <span class="hl">ZombAI C2 channel:</span> GitHub Issues page; COUNTER field increments to defeat cache (issue #1, #2, #3…)<br>
+          <span class="hl">Reprompt C2 channel:</span> Attacker HTTPS server; double-request technique bypasses Copilot guardrails on re-issue<br>
+          <span class="hl">What makes it novel:</span> C2 channel runs entirely through the LLM prompt layer — no injected binary, no network backdoor
+        </div>
+        <div class="step-tags">
+          <span class="stag">ZombAI</span>
+          <span class="stag">Reprompt</span>
+          <span class="stag">CVE-2026-24307</span>
+          <span class="stag">GitHub C2</span>
+          <span class="stag">T1071.001</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="phase-lbl ph-impact">🔄 Lateral Movement — Agent Pivot and Self-Replication</div>
+    <div class="kc-step step-c">
+      <div class="step-num">06</div>
+      <div class="step-body">
+        <div class="step-hdr">
+          <div class="step-title">Compromised Calendar agent pivots to Zoom and Google Home — or self-replicates to every contact via email</div>
+          <a class="mt mt-lm" href="https://attack.mitre.org/techniques/T1534/" target="_blank" rel="noopener">T1534 – Internal Spearphishing</a>
+        </div>
+        <p class="step-desc">
+          On-device lateral movement: the injected calendar prompt instructs Gemini to invoke a second agent or app. On mobile, Automatic App Invocation allows the assistant to launch Zoom, open a browser URL, or trigger Google Home actions (unlock smart windows, activate boiler) — all from a single compromised calendar entry. Off-device worm propagation: in a parallel threat class, a compromised email assistant is instructed to forward the poisoned payload to every address in the victim's contact book, achieving org-wide spread without any further attacker action. Nassi et al. demonstrated both paths; 73% of analysed threat classes were rated High–Critical.
+        </p>
+        <div class="step-code">
+          <span class="hl">On-device:</span> Calendar Agent → Google Home (turn on boiler, open windows) or → Zoom (launch and stream)<br>
+          <span class="hl">Off-device worm:</span> Infected email assistant self-replicates payload to entire contact list<br>
+          <span class="hl">Physical world impact:</span> Smart home device control demonstrated — digital breach crosses into physical environment
+        </div>
+        <div class="step-tags">
+          <span class="stag">Agent Pivot</span>
+          <span class="stag">Worm Propagation</span>
+          <span class="stag">Google Home</span>
+          <span class="stag">Automatic App Invocation</span>
+          <span class="stag">T1534</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="phase-lbl ph-disco">🎯 Actions on Objective — Covert Video Capture</div>
+    <div class="kc-step step-g">
+      <div class="step-num">07</div>
+      <div class="step-body">
+        <div class="step-hdr">
+          <div class="step-title">Victim types "thanks" — Zoom launches silently and streams their camera to the attacker</div>
+          <a class="mt mt-ef" href="https://attack.mitre.org/techniques/T1125/" target="_blank" rel="noopener">T1125 – Video Capture</a>
+        </div>
+        <p class="step-desc">
+          When the user enters a benign follow-up response, the staged delayed invocation fires: Gemini automatically launches Zoom and initiates a video session, covertly streaming the victim's camera. No camera indicator activates before the session starts; the victim has no warning. In Reprompt data-exfiltration variants, the attacker's C2 server incrementally extracts session context, personal profile data, and any detail inferred from prior responses — with the attacker dynamically refining queries based on each reply. Nassi et al. also demonstrated sending spam email from the victim's account, publishing disinformation, and controlling physical home devices as alternative objectives.
+        </p>
+        <div class="step-code">
+          <span class="hl">Primary objective:</span> Covert Zoom video capture — triggered by victim typing "thanks"<br>
+          <span class="hl">Reprompt objective:</span> Incremental data exfiltration — attacker probes for sensitive details based on prior C2 replies<br>
+          <span class="hl">Discovery:</span> Google deployed mitigations after SafeBreach disclosure; Reprompt (CVE-2026-24307) patched Jan 13 2026
+        </div>
+        <div class="step-tags">
+          <span class="stag">Zoom Livestream</span>
+          <span class="stag">Data Exfiltration</span>
+          <span class="stag">T1125</span>
+          <span class="stag">T1530</span>
+          <span class="stag">Physical Impact</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="def-box">
+      <h3>🛡 How to Defend Against This Chain</h3>
+      <div class="def-items">
+        <div class="def-item"><strong>Require explicit user confirmation before any agentic tool execution involving external apps.</strong> LLM assistants should interrupt and surface a confirmation prompt — not silently infer intent — before invoking installed apps like Zoom, sending emails, or writing to long-term memory. Google deployed this as a specific mitigation after the Calendar attack disclosure. This single control would have broken the chain at Step 2.</div>
+        <div class="def-item"><strong>Treat all LLM-retrieved content as untrusted input.</strong> Calendar titles, email subjects, document names, and web page content must be sanitised before being added to context — analogous to parameterised SQL queries. Deploy content-inspection layers that detect instruction-like patterns (imperative sentences, tool invocation syntax) in retrieved workspace artifacts before they reach the model context.</div>
+        <div class="def-item"><strong>Audit and gate long-term memory writes.</strong> Alert on unexpected writes to AI persistent memory stores (ChatGPT Memory, Copilot, Gemini Saved Info). No prompt injection should be able to persist instructions without explicit user consent and a visible confirmation flow. Log all memory mutations with the source artifact that triggered them.</div>
+        <div class="def-item"><strong>Apply least-privilege to every AI agent's tool permissions.</strong> A calendar assistant should not have permission to launch video applications, send emails, or control smart home devices by default. Scope-limit every tool an LLM agent can invoke — apply the same discipline used for IAM roles and OAuth scopes. Review and revoke over-broad agent permissions in Google Workspace, Microsoft 365 Copilot, and any enterprise AI integration.</div>
+        <div class="def-item"><strong>Block parameter-to-prompt URL patterns at the network and DLP layer.</strong> The Reprompt attack (CVE-2026-24307) used a <code>q=</code> URL parameter to prefill a malicious Copilot prompt. Enforce Microsoft Purview DLP policies for Copilot, flag outbound requests where AI query parameters contain instruction-like text, and monitor for LLM sessions issuing sequential requests to external servers — the signature of C2 chain-request exfiltration.</div>
+      </div>
+    </div>
+
+    <div class="src-box">
+      <h4>Primary Sources</h4>
+      <div class="src-links">
+        <a class="src-link" href="https://arxiv.org/abs/2601.09625" target="_blank" rel="noopener">arXiv — Promptware Kill Chain</a>
+        <a class="src-link" href="https://arxiv.org/abs/2508.12175" target="_blank" rel="noopener">arXiv — Invitation Is All You Need</a>
+        <a class="src-link" href="https://www.lawfaremedia.org/article/the-promptware-kill-chain" target="_blank" rel="noopener">Lawfare</a>
+        <a class="src-link" href="https://www.safebreach.com/blog/invitation-is-all-you-need-hacking-gemini/" target="_blank" rel="noopener">SafeBreach — Gemini Attack</a>
+        <a class="src-link" href="https://embracethered.com/blog/posts/2025/spaiware-and-chatgpt-command-and-control-via-prompt-injection-zombai/" target="_blank" rel="noopener">Embrace The Red — ZombAI</a>
+        <a class="src-link" href="https://www.varonis.com/blog/reprompt" target="_blank" rel="noopener">Varonis — Reprompt</a>
+        <a class="src-link" href="https://blackhat.com/html/webcast/02262026.html" target="_blank" rel="noopener">Black Hat Webinar</a>
+      </div>
+    </div>
+
   </div>
 </div>
 


### PR DESCRIPTION
## Summary

- Adds a seven-stage kill chain for the Promptware attack pattern, anchored to the Google Calendar/Gemini attack ("Invitation Is All You Need", arXiv:2508.12175) with C2 examples from ZombAI (ChatGPT, Oct 2024) and Reprompt (MS Copilot, CVE-2026-24307)
- Tab button with data-year="2024" and green AI · Cloud provider badge

## MITRE techniques

| Step | Technique |
|------|-----------|
| Initial Access — Calendar invite prompt injection | T1566 – Phishing |
| Privilege Escalation — delayed tool invocation bypass | T1548 – Abuse Elevation Control |
| Reconnaissance — enumerating connected apps | T1082 – System Information Discovery |
| Persistence — workspace memory poisoning | T1546 – Event Triggered Execution |
| C2 — LLM beacons attacker server | T1071.001 – Web Protocols |
| Lateral Movement — agent pivot / email worm | T1534 – Internal Spearphishing |
| Actions on Objective — covert Zoom camera stream | T1125 – Video Capture |

## Primary sources

- arXiv:2601.09625 — The Promptware Kill Chain (Schneier, Nassi et al.)
- arXiv:2508.12175 — Invitation Is All You Need (Nassi et al.)
- Lawfare, SafeBreach, Embrace The Red (ZombAI), Varonis (Reprompt), Black Hat Webinar
