### PR TITLE
fix(ci): use Aqua's Trivy install script

### DIFF
--- a/.github/workflows/gcp-deploy.yml
+++ b/.github/workflows/gcp-deploy.yml
@@ -98,11 +98,12 @@ jobs:
       # has been yanked from the Marketplace, breaking action resolution.
       - name: Install Trivy
         run: |
-          # Pin to a specific Trivy CLI version. Reproducible scans + we
-          # can audit what scanner code ran.
-          TRIVY_VERSION="0.59.1"
-          curl -fsSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
-            | sudo tar -xz -C /usr/local/bin trivy
+          # Aqua's official install script — handles version + arch
+          # detection without us guessing the asset filename. Pinned to a
+          # specific Trivy release for reproducibility.
+          TRIVY_VERSION="v0.58.1"
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+            | sudo sh -s -- -b /usr/local/bin "${TRIVY_VERSION}"
           trivy --version
 
       - name: Trivy scan (fail on HIGH/CRITICAL)


### PR DESCRIPTION
## Summary

PR #654 swapped the broken Trivy *action* for a direct CLI download, but the URL I used (`trivy_0.59.1_Linux-64bit.tar.gz`) 404'd — version + asset name doesn't exist. Switching to Aqua's official `install.sh`, which resolves the asset URL itself based on runner arch and the version we pin (v0.58.1, a confirmed release).

## Test plan

- [ ] After merge: `gcp-deploy.yml` Install Trivy step succeeds, scan runs, image deploys to Cloud Run via WIF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)