### PR TITLE
fix(docker): apk upgrade to clear stale base-image CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,15 @@
 #             docker inspect --format='{{index .RepoDigests 0}}' nginx:1.27-alpine`
 FROM nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
 
+# Refresh Alpine packages on top of the pinned base. The digest pin
+# guarantees we start from known bytes, but the packages baked into that
+# digest age — `apk upgrade` pulls current versions from Alpine's repos,
+# picking up security patches (libssl3, libxml2, libpng, etc.) without
+# losing reproducibility on the base layer. Trivy will catch any HIGH/
+# CRITICAL CVEs that survive this step.
+RUN apk upgrade --no-cache && \
+    rm -rf /var/cache/apk/*
+
 # Copy custom nginx config that mirrors .htaccess security rules.
 # The security-headers snippet is `include`d into every location block;
 # without that, nginx's add_header inheritance gets clobbered by the


### PR DESCRIPTION
## Summary

Trivy CI scan caught real CVEs in the digest-pinned `nginx:1.27-alpine` base — the SHA pin is several months old, so the alpine packages have aged and accumulated HIGH/CRITICAL fixes (libssl3, libxml2, libpng, musl, nghttp2, zlib).

Adding `apk upgrade --no-cache` after `FROM`. The digest pin still guarantees we start from known bytes (supply-chain integrity), but `apk` pulls current package versions from Alpine repos so we don't ship known-vulnerable libraries.

## Test plan

- [x] Local build succeeds
- [ ] After merge: `gcp-deploy.yml` Trivy scan passes (or surfaces only fix-unavailable CVEs which `--ignore-unfixed` already filters)
- [ ] Image deploys to Cloud Run revision via WIF — final end-to-end keyless deploy verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)