### PR TITLE
docs: document GCP Cloud Run deploy path alongside FTPS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -571,7 +571,7 @@ Before you submit, make sure:
 
 ### What happens after your PR merges
 
-`site-update-deploy.yml` runs SRI hashing, URL safety checks, URL normalization, preview-image generation, broken-link checks, and the FTP deploy. You don't need to run any of that locally — see [README.md#how-automation-works](README.md#-how-automation-works) for the full pipeline.
+Two deploy workflows run in parallel during the LiteSpeed → GCP migration: `site-update-deploy.yml` (SRI hashing, URL safety checks, URL normalization, preview-image generation, broken-link checks, plus FTPS deploy to LiteSpeed) and `gcp-deploy.yml` (build, Trivy scan, deploy to Cloud Run via Workload Identity Federation). After Cloudflare DNS for `csoh.org`/`www.csoh.org` cuts over to the GCP load balancer, the FTPS path is retired. You don't need to run any of this locally — see [README.md#how-automation-works](README.md#-how-automation-works) for the full pipeline.
 
 **Quick tips for URLs you add:**
 - Use HTTPS when available.

--- a/README.md
+++ b/README.md
@@ -585,9 +585,33 @@ In addition to the URL normalization that runs as part of every deploy, a **stan
 
 A manual-trigger-only workflow that force-pushes the entire site to the FTP host. Use it when the auto-deploy skipped a push (no relevant files changed) or the server got out of sync with `main`. Triggered from the GitHub Actions tab — it never runs on push.
 
+### GCP Cloud Run Deploy Workflow (in migration)
+
+**Workflow file:** `.github/workflows/gcp-deploy.yml`
+
+Builds a container image, scans it for HIGH/CRITICAL CVEs, pushes to Artifact Registry, and deploys to Cloud Run. **Currently runs in parallel with the FTPS deploy** while we migrate hosting from LiteSpeed to GCP. After the Cloudflare DNS cutover for `csoh.org`/`www.csoh.org` is complete and verified, the FTPS step in `site-update-deploy.yml` is removed and `manual-deploy.yml` is deleted.
+
+**Triggers on pushes to `main` when these files change:**
+- The same path filters as `site-update-deploy.yml` (HTML, CSS, JS, screenshots, images)
+- `Dockerfile`, `nginx.conf`, `.github/workflows/gcp-deploy.yml`
+- Manual trigger via the GitHub Actions tab
+
+**What it does:**
+- Authenticates to GCP via **Workload Identity Federation** — no service account JSON key is stored or rotated. The OIDC token GitHub mints for the run is exchanged at run-time for a 1-hour GCP access token, gated to this repository only.
+- Builds the container with `Dockerfile` (digest-pinned `nginx:1.27-alpine` + `apk upgrade` + the `nginx-security-headers.conf` snippet that's `include`d into every location block).
+- Runs Trivy against the built image; build fails on any HIGH or CRITICAL CVE that has a fix available.
+- Pushes to Artifact Registry with an immutable SHA-based tag (no `:latest`).
+- Deploys a new Cloud Run revision pinned to that SHA.
+
+**Edge in front of Cloud Run:** Global HTTPS load balancer with Cloud CDN and Cloud Armor (OWASP CRS WAF, per-IP rate limit, adaptive L7 DDoS), modern TLS policy (1.2+), HTTP→HTTPS redirect. Logs (LB requests, Cloud Armor blocks, IAM admin activity, audit logs) route to a 400-day-retention bucket.
+
+**Full architecture and bootstrap steps:** [infra/README.md](infra/README.md). Security model and rotation: [SECURITY.md → Deployment Security](SECURITY.md#deployment-security).
+
 ### Setup Note
 
 Workflows authenticate to GitHub via a **GitHub App** (`csoh-ci`) that mints short-lived (~1h) installation tokens at job start, plus a small fine-grained PAT (`CSOH_PAT`) used only to approve App-opened PRs (GitHub blocks self-approval). The full model — App config, ruleset bypass, why one PAT remains — is documented in [SECURITY.md → CI/CD Authentication](SECURITY.md#cicd-authentication). Setup / rotation steps for the PAT are in [tools/UPDATE_NEWS_README.md](tools/UPDATE_NEWS_README.md#setup-requirements).
+
+`gcp-deploy.yml` does *not* use the GitHub App — it authenticates to GCP via Workload Identity Federation and only needs the auto-injected `GITHUB_TOKEN` (with `id-token: write` for the OIDC exchange). There is no GCP-side credential to set up or rotate.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,16 @@ This document describes the security measures in place for [csoh.org](https://cs
 
 ## Architecture
 
-csoh.org is a **pure static site** — no server-side code, no database, no user accounts, no cookies, no sessions. This eliminates entire classes of vulnerabilities (SQL injection, RCE, auth bypass, session hijacking, CSRF). Content is served from shared hosting (LiteSpeed) with FTPS deployment via GitHub Actions.
+csoh.org is a **pure static site** — no server-side code, no database, no user accounts, no cookies, no sessions. This eliminates entire classes of vulnerabilities (SQL injection, RCE, auth bypass, session hijacking, CSRF).
+
+**Hosting is being migrated from shared LiteSpeed (FTPS-deployed) to Google Cloud Run (container-based, GitHub Actions-deployed via Workload Identity Federation).** Both paths run in parallel during the transition:
+
+| Path | Status | Domain | Deploy mechanism |
+|------|--------|--------|------------------|
+| LiteSpeed shared host | Production today | `csoh.org`, `www.csoh.org` | FTPS via `lftp` from `site-update-deploy.yml`, credentials in GitHub Secrets |
+| Google Cloud Run | Staging (verified) | `gcp.csoh.org` | Container deploy via `gcp-deploy.yml`, **no service-account key** — auth is short-lived OIDC tokens minted by GitHub and exchanged for GCP access tokens via Workload Identity Federation |
+
+After the Cloudflare DNS cutover (`csoh.org` and `www` move to the GCP load balancer), the FTPS path is retired and FTP secrets are removed from the repo. The full GCP architecture — Cloud Run, HTTPS load balancer, Cloud Armor WAF, Cloud CDN, managed TLS, Workload Identity Federation, Artifact Registry with immutable tags, 400-day log retention — is documented in [infra/README.md](infra/README.md).
 
 ---
 
@@ -189,13 +198,14 @@ CI workflows authenticate to GitHub via a **GitHub App** (`csoh-ci`) rather than
 
 ### Authentication model
 
-| Workflow | Auth | Pushes to main? |
-|----------|------|------|
-| `update-news.yml` | `csoh-ci` App + `CSOH_PAT` (for auto-approve) | via PR + auto-merge |
-| `normalize-urls.yml` | `csoh-ci` App | via PR (human reviews + merges) |
-| `site-update-deploy.yml` | `csoh-ci` App | direct (App is on ruleset bypass) |
-| `manual-deploy.yml` | none (FTP only) | no |
-| `lint.yml`, `validate-html.yml`, `check-broken-links.yml`, `check-url-safety.yml` | auto-injected `GITHUB_TOKEN` | no |
+| Workflow | Auth (GitHub side) | Auth (deploy target) | Pushes to main? |
+|----------|---------|----------------------|------|
+| `update-news.yml` | `csoh-ci` App + `CSOH_PAT` (for auto-approve) | n/a | via PR + auto-merge |
+| `normalize-urls.yml` | `csoh-ci` App | n/a | via PR (human reviews + merges) |
+| `site-update-deploy.yml` | `csoh-ci` App | FTPS — `FTP_HOST`/`FTP_USER`/`FTP_PASS` secrets | direct (App is on ruleset bypass) |
+| `manual-deploy.yml` | n/a | FTPS — same secrets | no |
+| `gcp-deploy.yml` | auto-injected `GITHUB_TOKEN` (`id-token: write` for OIDC) | **WIF — no key** (impersonates `csoh-deployer` SA via OIDC) | no |
+| `lint.yml`, `validate-html.yml`, `check-broken-links.yml`, `check-url-safety.yml` | auto-injected `GITHUB_TOKEN` | n/a | no |
 
 Every workflow declares an explicit top-level `permissions:` block scoping the auto-injected `GITHUB_TOKEN`. The four read-only check workflows use `contents: read` (plus `pull-requests: write` where they post comments). The four write-capable workflows (`update-news`, `normalize-urls`, `site-update-deploy`, `manual-deploy`) declare `contents: read` for the auto-injected token, because they handle write access through the App or PAT instead — keeping the default token strictly minimal.
 
@@ -269,8 +279,19 @@ GitHub's auto-merge feature evaluates `reviewDecision` independently and does no
 | `CSOH_CI_CLIENT_ID` | GitHub App's Client ID (`Iv23.*`) | identifier (not sensitive on its own) |
 | `CSOH_CI_PRIVATE_KEY` | GitHub App's RSA private key | high-sensitivity |
 | `CSOH_PAT` | Approve App-opened PRs (auto-merge driver) | medium-sensitivity (narrow scope) |
-| `FTP_HOST`, `FTP_USER`, `FTP_PASS` | FTPS deploy credentials | high-sensitivity |
+| `FTP_HOST`, `FTP_USER`, `FTP_PASS` | FTPS deploy credentials (**retired post-cutover**) | high-sensitivity |
 | `SSH_PRIVATE_KEY` | Reserved for future use | high-sensitivity |
+
+**No GCP secret in this list — that's deliberate.** The `gcp-deploy.yml` workflow needs no service-account key, no project-scoped PAT, and no GCP-side stored secret. It authenticates by:
+
+1. GitHub Actions mints an OIDC token for the run, signed by GitHub's identity provider.
+2. Google Cloud's STS exchanges that token for a short-lived (1-hour) access token, gated by a Workload Identity Federation policy that requires:
+   - `assertion.repository == 'CloudSecurityOfficeHours/csoh.org'` (other repos cannot mint tokens for this pool)
+   - `aud` matching the configured pool/provider
+3. The access token is scoped to impersonating one specific service account (`csoh-deployer`) which has narrowly-scoped roles: `roles/run.admin`, `roles/artifactregistry.writer`, plus `iam.serviceAccountUser` on the runtime SA.
+4. The runtime SA (`csoh-run-runtime`, what the actual container runs as) has **zero IAM roles** — the static container makes no GCP API calls, so it gets nothing.
+
+Net effect: a leaked workflow log compromises one ~1-hour token scoped to one repo's deploy permissions on one project. There is no long-lived credential to rotate or revoke.
 
 `PAT_TOKEN` (the original CI PAT), `CSOH_CI_APP_ID` (deprecated numeric input, replaced by `CSOH_CI_CLIENT_ID`), and `APPROVAL_PAT_TOKEN` (replaced by `CSOH_PAT`) have all been removed.
 
@@ -283,15 +304,50 @@ GitHub's auto-merge feature evaluates `reviewDecision` independently and does no
 | App installation token | Automatic, every ~1 hour | None — handled by GitHub |
 | App private key | Annually or on suspected compromise | Generate new key in App settings; replace `CSOH_CI_PRIVATE_KEY` secret; revoke old key |
 | `CSOH_PAT` | Every 6–12 months (or before its set expiry) | Generate new fine-grained PAT (resource owner: `CloudSecurityOfficeHours`, repo: `csoh.org`, permission: pull-requests: write only); replace org-level Actions secret |
-| `FTP_PASS` | Every 6–12 months | Rotate via hosting panel; replace secret |
+| `FTP_PASS` (retired post-cutover) | Every 6–12 months while in use | Rotate via hosting panel; replace secret. After GCP cutover, delete all three FTP secrets. |
+| GCP WIF access token | Automatic, every ~1 hour | None — minted per workflow run, no stored credential |
+| GCP runtime SA roles | On every Terraform apply | The runtime SA's IAM bindings live in [`infra/terraform/service_accounts.tf`](infra/terraform/service_accounts.tf) — review on every change |
 
 ---
 
 ## Deployment Security
 
-### FTPS Deployment
+Two deploy paths run in parallel during the LiteSpeed → GCP migration. After Cloudflare DNS cuts over to the GCP load balancer, the FTPS path is retired and the FTP secrets are deleted.
 
-The site deploys via FTPS (FTP over TLS) using `lftp` from GitHub Actions:
+### Cloud Run Deployment (post-migration target)
+
+`gcp-deploy.yml` builds a container image, scans it, and deploys to Cloud Run on every push to `main` that touches site files.
+
+**Authentication — Workload Identity Federation, no stored credential:**
+- GitHub Actions mints an OIDC token for the run.
+- A WIF policy in the GCP project gates the exchange: only OIDC tokens whose `repository` claim equals `CloudSecurityOfficeHours/csoh.org` are accepted ([`infra/terraform/wif.tf`](infra/terraform/wif.tf)).
+- The exchanged GCP access token is short-lived (~1 hour), scoped to impersonating the `csoh-deployer` service account.
+- The deploy SA has only the roles needed to push images and deploy revisions — no broader project access.
+- The runtime SA the container runs as (`csoh-run-runtime`) has **zero IAM roles**.
+
+**Image supply chain:**
+- Base image (`nginx:1.27-alpine`) is **digest-pinned** in the [`Dockerfile`](Dockerfile). A compromised registry tag cannot ship malicious bytes into our build.
+- `RUN apk upgrade --no-cache` after `FROM` refreshes Alpine packages on top of the pinned base — supply-chain integrity for the base layer plus current security patches for libraries.
+- Every PR's container is **Trivy-scanned** for HIGH and CRITICAL CVEs (with fixes available); the build fails if any are found.
+- Artifact Registry has `immutable_tags=true` — once an image tag is pushed, it cannot be overwritten or moved. Cloud Run revisions pin a specific SHA tag, so rollback is `gcloud run services update-traffic --to-revisions <name>=100` and there is no ambiguity about what bytes ran.
+- Cleanup policy keeps the most recent 30 versions and deletes untagged versions older than 7 days.
+
+**Workflow hardening:**
+- `permissions:` block scopes the auto-injected `GITHUB_TOKEN` to `contents: read` + `id-token: write` (id-token is required by WIF; nothing else is granted).
+- The deploy job is gated by the `production` GitHub Environment, which is configured in repo settings to allow deployments only from `main` and to enforce Code Owners review on the workflow file via [`.github/CODEOWNERS`](.github/CODEOWNERS). A PR from a fork cannot reach this code path even if it could otherwise mint an OIDC token, because protected-environment policies only apply on `main`.
+
+**Edge defenses (load balancer in front of Cloud Run):**
+- **Cloud Armor** policy with OWASP Core Rule Set (SQLi, XSS, LFI, RFI, RCE), per-IP rate limit (600 req/min, 10-min ban on exceed), and adaptive L7 DDoS defense ([`infra/terraform/cloud_armor.tf`](infra/terraform/cloud_armor.tf)).
+- **Modern TLS policy** — TLS 1.2+ only, restricted cipher suite.
+- **HTTP→HTTPS redirect** at the LB; the Cloud Run service's ingress is `internal-and-cloud-load-balancing` so direct hits to the Run URL get blocked at the edge.
+
+**Logging:**
+- LB request logs, Cloud Armor decisions, IAM admin activity, and audit logs are routed to a 400-day retention bucket via the security log sink in [`infra/terraform/logging.tf`](infra/terraform/logging.tf) (the default `_Default` sink only retains 30 days).
+
+### FTPS Deployment (legacy, retiring during cutover)
+
+The site currently deploys via FTPS (FTP over TLS) using `lftp` from GitHub Actions to LiteSpeed shared hosting. This path **runs in parallel** with `gcp-deploy.yml` during migration; both publish the same source-of-truth bytes to different hosts.
+
 - `ssl:verify-certificate yes` — **validates the FTP host's TLS cert chain and hostname.** An on-path attacker cannot present a forged cert and capture the FTP credentials.
 - `ftp:ssl-force true` — enforces TLS encryption on the control channel (refuses plaintext FTP)
 - `ftp:ssl-protect-data true` — encrypts file transfers, not just the control channel
@@ -299,6 +355,8 @@ The site deploys via FTPS (FTP over TLS) using `lftp` from GitHub Actions:
 - Credentials are stored as GitHub repository secrets (`FTP_HOST`, `FTP_USER`, `FTP_PASS`).
 
 The deploy workflow (`site-update-deploy.yml`) authenticates to GitHub via the `csoh-ci` App for its housekeeping commits (SRI hash updates, sitemap refreshes, etc.) — see [CI/CD Authentication](#cicd-authentication) above. FTP credentials are entirely separate and not affected by App-token rotation.
+
+**Retirement plan:** after Cloudflare DNS for `csoh.org` and `www.csoh.org` is moved to the GCP LB and traffic is verified, the FTP `lftp` step in `site-update-deploy.yml` is removed (the housekeeping steps stay), `manual-deploy.yml` is deleted, and the three FTP secrets are removed from the repo.
 
 ### Deployment Exclusions
 


### PR DESCRIPTION
## Summary

Documents the GCP Cloud Run deploy path that's been merged + working on `gcp.csoh.org` so the docs match reality before we flip Cloudflare DNS for `csoh.org`/`www.csoh.org` over to the GCP load balancer.

Touches three docs:

- **`SECURITY.md`** — biggest change. Architecture section now describes both hosting paths and the migration plan. Auth-model table splits "GitHub side" vs "deploy target" auth so the WIF-no-key story is visible. New explicit note in the secrets table about why there is no GCP secret. Rotation table picks up GCP entries. Deployment Security section gains a new "Cloud Run Deployment" subsection covering WIF, image supply chain, workflow hardening, edge defenses, and logging — with the existing FTPS section preserved and labeled "legacy, retiring during cutover."
- **`README.md`** — adds a "GCP Cloud Run Deploy Workflow" subsection under How Automation Works, with a pointer to [`infra/README.md`](infra/README.md) for full architecture.
- **`CONTRIBUTING.md`** — one-line update so contributors know two deploy workflows fire on PR merge today.

After cutover, a separate PR removes the FTPS sections entirely, deletes `manual-deploy.yml` + the `lftp` step in `site-update-deploy.yml`, and clears the `FTP_*` secrets from the repo.

## Test plan

- [x] Renders correctly on GitHub (markdown tables, code blocks, links to infra/ and SECURITY.md anchors)
- [x] Required CI checks pass (ruff, actionlint, yamllint)
- [ ] Sanity-check after merge: doc cross-links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)