### PR TITLE
infra(cert): rename TF resource csoh-cert-staging-only → csoh-cert-gcp

### DIFF
--- a/infra/terraform/load_balancer.tf
+++ b/infra/terraform/load_balancer.tf
@@ -84,7 +84,7 @@ resource "google_compute_url_map" "https_redirect" {
 # "cert in use, cannot delete" cascade).
 resource "google_compute_managed_ssl_certificate" "site" {
   project = var.project_id
-  name    = "csoh-cert-staging-only"
+  name    = "csoh-cert-gcp"
   managed {
     domains = [var.staging_domain]
   }


### PR DESCRIPTION
## Summary

During tonight's Path A cutover the managed SSL cert had to be manually recreated via `gcloud` because it got stuck in `PROVISIONING` with a stale per-domain ACTIVE state that the LB wouldn't actually serve. The recreate used a new name (`csoh-cert-gcp`) since GCP doesn't allow detaching the only cert from a `target_https_proxy` without specifying a replacement.

Terraform state and config are now reconciled with reality:

- `name: csoh-cert-staging-only` → `csoh-cert-gcp` (matches actual GCP resource)
- Imported the actual cert into TF state with the new resource address before pushing, so `terraform plan` is clean for the cert resource itself.

## Test plan

- [x] `terraform plan` shows no destructive changes for the cert
- [x] Production verified healthy: `https://csoh.org` 200 via Cloudflare with all 8 security headers, `https://gcp.csoh.org` 200 direct with valid Google-issued cert
- [ ] After merge: any future `terraform apply` won't try to recreate the cert

## Known drift (separate fix)

There's unrelated Cloud Run drift — GCP auto-added a service-level `scaling` block that we don't manage in TF. It's a no-op at apply time but surfaces as an "in-place update" in plans. Will fix in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)