### PR TITLE
infra(cloud-run): declare service-level scaling block to fix plan drift

### DIFF
--- a/infra/terraform/cloud_run.tf
+++ b/infra/terraform/cloud_run.tf
@@ -8,6 +8,15 @@ resource "google_cloud_run_v2_service" "site" {
 
   ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
 
+  # Service-level scaling. This is separate from `template.scaling` (which
+  # configures per-revision auto-scaling). The Cloud Run v2 API populates
+  # this block with default zeros on every service whether you declare it
+  # or not — declaring it explicitly here keeps `terraform plan` clean
+  # rather than showing a perpetual "remove this block" no-op diff.
+  scaling {
+    min_instance_count = 0
+  }
+
   template {
     service_account = google_service_account.cloud_run_runtime.email
 


### PR DESCRIPTION
## Summary

The Cloud Run v2 API populates a service-level `scaling` block on every service with default zeros (`manual_instance_count = 0`, `min_instance_count = 0`) regardless of whether you declare it. Our Terraform only declared `template.scaling` (per-revision auto-scale config), so every `terraform plan` showed a perpetual "remove this scaling block" no-op diff.

Declaring it explicitly with the API-default value removes the drift.

```hcl
scaling {
  min_instance_count = 0
}
```

## Test plan

- [x] `terraform plan` returns "No changes. Your infrastructure matches the configuration." after the change
- [x] No production impact (operationally identical — the field was already at default zero on the live resource)

🤖 Generated with [Claude Code](https://claude.com/claude-code)