### PR TITLE
infra: pin remaining package versions for supply-chain reproducibility

### DIFF
--- a/.github/workflows/gcp-deploy.yml
+++ b/.github/workflows/gcp-deploy.yml
@@ -98,18 +98,29 @@ jobs:
       # has been yanked from the Marketplace, breaking action resolution.
       - name: Install Trivy
         run: |
-          # Install via Aqua's apt repository. Stable, signed packages, no
-          # asset-name guessing. The previous attempts (direct GH release
-          # tarball, `install.sh`) failed silently — apt is what Aqua
-          # recommends in their docs for CI runners and gives clear errors.
+          # Pinned download from Aqua's GitHub releases + SHA-256 verify.
+          #
+          # Why pin instead of `apt install trivy` from Aqua's repo: the
+          # apt repo serves whatever Trivy version Aqua last published —
+          # works in practice, but it means every CI run pulls a different
+          # scanner binary as new releases ship, with no record in this
+          # repo of which scanner actually ran. Hardcoding version +
+          # checksum here gives us supply-chain reproducibility (today's
+          # CI run uses the exact same scanner code as last week's), and
+          # any tampering with the download fails the sha256sum check.
+          #
+          # To bump: pick a new version from
+          #   https://github.com/aquasecurity/trivy/releases
+          # and copy the matching SHA from the release's checksums.txt
+          # (also available as a `*.sigstore.json` signed attestation).
           set -euo pipefail
-          sudo apt-get install -y wget gnupg lsb-release
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key \
-            | sudo gpg --dearmor -o /usr/share/keyrings/trivy.gpg
-          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" \
-            | sudo tee /etc/apt/sources.list.d/trivy.list > /dev/null
-          sudo apt-get update
-          sudo apt-get install -y trivy
+          TRIVY_VERSION="0.70.0"
+          TRIVY_SHA256="8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9"
+          curl -fsSL -o /tmp/trivy.tar.gz \
+            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          echo "${TRIVY_SHA256}  /tmp/trivy.tar.gz" | sha256sum -c -
+          sudo tar -xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy
+          rm /tmp/trivy.tar.gz
           trivy --version
 
       - name: Trivy scan (fail on HIGH/CRITICAL)

--- a/.github/workflows/site-update-deploy.yml
+++ b/.github/workflows/site-update-deploy.yml
@@ -100,9 +100,11 @@ jobs:
 
       # Install Playwright + Pillow (used by generate_preview.py to capture
       # and resize screenshots) plus a headless Chromium binary.
+      # Pinned versions: bump deliberately when needed rather than picking
+      # up whatever PyPI happens to ship today (supply-chain reproducibility).
       - name: Install dependencies
         run: |
-          pip install playwright Pillow
+          pip install 'playwright==1.59.0' 'Pillow==12.2.0'
           playwright install chromium
 
       # --- SRI hashes are always updated and committed BEFORE any deploy step ---


### PR DESCRIPTION
## Summary

Two unpinned package installs surfaced in the post-merge audit. Pinning both.

### 1. `pip install playwright Pillow` (in `site-update-deploy.yml`)

Picked up whatever PyPI shipped that day. A malicious release would have slipped into the screenshot-generation step that runs on every merge to main and commits files back to the repo. Pinned:

```
playwright==1.59.0
Pillow==12.2.0
```

### 2. `apt install -y trivy` from Aqua's apt repo (in `gcp-deploy.yml`)

Pulled whatever Trivy version Aqua last published, with no record in this repo of which scanner actually ran. Replaced with a pinned tarball download from GitHub releases + SHA-256 verify:

```
TRIVY_VERSION=0.70.0
TRIVY_SHA256=8b4376d5...d9e0c49f9127a4279fd110b727929a5aa9
```

Both values live in the workflow file and the SHA matches the official `trivy_0.70.0_checksums.txt` from Aqua's GitHub release (verified locally). Also drops the apt-get + GPG + lsb-release dance — one less moving part.

To bump Trivy in future: pick a new version from <https://github.com/aquasecurity/trivy/releases> and copy the matching SHA from `checksums.txt`. The workflow comment explains.

### What's still unpinned and why

- `apt-get install -y jpegoptim` and `wget gnupg lsb-release` — foundational Ubuntu utilities; the runner image SHA effectively pins them at the OS layer.
- gcloud SDK (via `google-github-actions/setup-gcloud`) — action SHA is pinned but the action installs whatever gcloud is current. Could add `version:` input, but Google ships gcloud frequently and there's no real risk vector there.

## Test plan

- [x] Workflow YAML still parses
- [x] SHA-256 of `trivy_0.70.0_Linux-64bit.tar.gz` verified to match Aqua's published `checksums.txt`
- [ ] After merge: next `gcp-deploy.yml` run installs Trivy via the new pinned-tarball path and the scan still passes
- [ ] After merge: next `site-update-deploy.yml` run installs the pinned `playwright`/`Pillow` and the preview-image step still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)