### PR TITLE
infra(ci): bump Node-20 actions to Node-24 SHAs in gcp-deploy.yml

### DIFF
--- a/.github/workflows/gcp-deploy.yml
+++ b/.github/workflows/gcp-deploy.yml
@@ -54,17 +54,17 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Authenticate to GCP via WIF
         id: auth
-        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f  # v2.1.7
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3
         with:
           workload_identity_provider: projects/23727240440/locations/global/workloadIdentityPools/github-pool/providers/github-provider
           service_account: csoh-deployer@csoh-org-495800.iam.gserviceaccount.com
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a  # v2.1.4
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3.0.1
 
       - name: Configure docker auth for Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet


### PR DESCRIPTION
## Summary

GitHub deprecation notice from the run logs: actions running on Node.js 20 will be forced to Node 24 by default starting **June 2026**, with Node 20 removed from runners by **September 2026**.

Three actions in `gcp-deploy.yml` were pinned to Node-20-era SHAs. Bumping all three to current major-version SHAs that run on Node 24:

| Action | Old | New |
|---|---|---|
| `actions/checkout` | `11bd7190…` (v4.2.2) | `de0fac2e…` (v6.0.2 — same SHA the other workflows already use) |
| `google-github-actions/auth` | `6fc4af4b…` (v2.1.7) | `7c6bc770…` (v3) |
| `google-github-actions/setup-gcloud` | `77e7a554…` (v2.1.4) | `aa5489c8…` (v3.0.1) |

All three are major-version bumps but the input contracts we use are stable:
- `auth` still takes `workload_identity_provider` + `service_account`
- `setup-gcloud` takes no inputs in our usage
- `checkout` v6 has the same default behavior as v4 for our use

Other workflows in the repo were already on Node-24-compatible SHAs.

## Test plan

- [x] YAML still parses
- [x] Required CI checks (ruff, actionlint, yamllint)
- [ ] After merge: `gcp-deploy.yml` runs through to deployment with the new action versions; the deprecation warnings should no longer appear in run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)