### PR TITLE
docs: fix dark-mode contrast on cloud-deployment SVG diagrams

### DIFF
--- a/cloud-deployment.html
+++ b/cloud-deployment.html
@@ -290,10 +290,16 @@
                 <desc id="arch-desc">A top-to-bottom flow diagram showing the request path from browser through Cloudflare, GCP HTTPS load balancer, and Cloud Run; a parallel build path on the right showing GitHub Actions, OIDC, and Artifact Registry; and a logging sink underneath.</desc>
                 <defs>
                   <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-                    <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+                    <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
                   </marker>
                 </defs>
                 <style>
+                  /* Box fills + strokes are fixed pastels — they stand
+                     out on both light and dark backgrounds. Text INSIDE
+                     boxes is hardcoded dark because it sits on light
+                     fills. Connector arrows + labels OUTSIDE boxes use
+                     currentColor so they pick up the page's text colour
+                     and stay readable in both light and dark mode. */
                   .arch-box { fill: #fff; stroke: #475569; stroke-width: 1.5; }
                   .arch-box-cf  { fill: #fef3c7; stroke: #f59e0b; }
                   .arch-box-lb  { fill: #dbeafe; stroke: #2563eb; }
@@ -304,8 +310,9 @@
                   .arch-title { font: 700 13px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: #0f172a; }
                   .arch-sub   { font: 11px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: #334155; }
                   .arch-tag   { font: 10px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: #64748b; }
-                  .arch-edge  { stroke: #475569; stroke-width: 1.6; fill: none; }
-                  .arch-edge-dash { stroke: #94a3b8; stroke-width: 1.4; fill: none; stroke-dasharray: 5 4; }
+                  .arch-conn  { font: 10px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: currentColor; opacity: 0.75; }
+                  .arch-edge  { stroke: currentColor; stroke-width: 1.6; fill: none; opacity: 0.8; }
+                  .arch-edge-dash { stroke: currentColor; stroke-width: 1.4; fill: none; stroke-dasharray: 5 4; opacity: 0.45; }
                 </style>
 
                 <!-- Browser -->
@@ -314,7 +321,7 @@
 
                 <!-- Arrow to Cloudflare -->
                 <line x1="200" y1="62" x2="200" y2="98" class="arch-edge" marker-end="url(#arr)"/>
-                <text x="210" y="84" class="arch-tag">HTTPS · sees Cloudflare's cert</text>
+                <text x="210" y="84" class="arch-conn">HTTPS · sees Cloudflare's cert</text>
 
                 <!-- Cloudflare -->
                 <rect x="40" y="100" width="320" height="100" rx="8" class="arch-box arch-box-cf"/>
@@ -325,7 +332,7 @@
 
                 <!-- Arrow to LB -->
                 <line x1="200" y1="200" x2="200" y2="240" class="arch-edge" marker-end="url(#arr)"/>
-                <text x="210" y="225" class="arch-tag">HTTPS · separate connection</text>
+                <text x="210" y="225" class="arch-conn">HTTPS · separate connection</text>
 
                 <!-- Load balancer -->
                 <rect x="40" y="242" width="320" height="130" rx="8" class="arch-box arch-box-lb"/>
@@ -338,7 +345,7 @@
 
                 <!-- Arrow to Cloud Run -->
                 <line x1="200" y1="372" x2="200" y2="412" class="arch-edge" marker-end="url(#arr)"/>
-                <text x="210" y="397" class="arch-tag">internal-only ingress</text>
+                <text x="210" y="397" class="arch-conn">internal-only ingress</text>
 
                 <!-- Cloud Run -->
                 <rect x="40" y="414" width="320" height="140" rx="8" class="arch-box arch-box-run"/>
@@ -401,7 +408,7 @@
 
                 <!-- Cross-arrow: deploy → Cloud Run service -->
                 <path d="M 540 516 Q 460 516 410 484" class="arch-edge-dash" marker-end="url(#arr)"/>
-                <text x="430" y="510" class="arch-tag" text-anchor="end">configures →</text>
+                <text x="430" y="510" class="arch-conn" text-anchor="end">configures →</text>
 
                 <!-- ===== Bottom: logging ===== -->
                 <rect x="100" y="608" width="680" height="80" rx="8" class="arch-box arch-box-log"/>
@@ -568,10 +575,15 @@
                 <desc id="wif-desc">A sequence diagram showing five steps for the GitHub Actions runner to obtain a 1-hour Google Cloud access token without any stored credential: GitHub mints an OIDC token, the runner presents it to GCP STS, STS verifies it against a policy that pins the repo, STS returns a short-lived access token, the runner uses it to deploy.</desc>
                 <defs>
                   <marker id="wif-arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-                    <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+                    <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
                   </marker>
                 </defs>
                 <style>
+                  /* Same dark/light strategy as the architecture
+                     diagram: pastel box fills + dark text inside boxes
+                     stay constant; lifelines, arrows and between-actor
+                     labels use currentColor so they pick up the page
+                     text colour. */
                   .wif-actor   { fill: #fff; stroke: #334155; stroke-width: 1.5; }
                   .wif-gha     { fill: #d1fae5; stroke: #059669; }
                   .wif-gh-id   { fill: #fef3c7; stroke: #f59e0b; }
@@ -581,8 +593,10 @@
                   .wif-s       { font: 700 11px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: #0f172a; }
                   .wif-d       { font: 11px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: #475569; }
                   .wif-tag     { font: 10px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: #64748b; }
-                  .wif-edge    { stroke: #475569; stroke-width: 1.6; fill: none; }
-                  .wif-life    { stroke: #cbd5e1; stroke-width: 1; stroke-dasharray: 3 3; }
+                  .wif-d-conn  { font: 11px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: currentColor; opacity: 0.85; }
+                  .wif-tag-conn{ font: 10px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: currentColor; opacity: 0.65; }
+                  .wif-edge    { stroke: currentColor; stroke-width: 1.6; fill: none; opacity: 0.8; }
+                  .wif-life    { stroke: currentColor; stroke-width: 1; stroke-dasharray: 3 3; opacity: 0.35; }
                 </style>
 
                 <!-- Actor headers -->
@@ -612,22 +626,22 @@
                 <line x1="130" y1="100" x2="340" y2="100" class="wif-edge" marker-end="url(#wif-arr)"/>
                 <circle cx="118" cy="100" r="11" fill="#059669"/>
                 <text x="118" y="104" text-anchor="middle" class="wif-s" fill="#fff">1</text>
-                <text x="235" y="92"  text-anchor="middle" class="wif-d">"give me an OIDC token for this run"</text>
-                <text x="235" y="115" text-anchor="middle" class="wif-tag">permissions: id-token: write</text>
+                <text x="235" y="92"  text-anchor="middle" class="wif-d-conn">"give me an OIDC token for this run"</text>
+                <text x="235" y="115" text-anchor="middle" class="wif-tag-conn">permissions: id-token: write</text>
 
                 <!-- Step 2: GitHub returns OIDC token -->
                 <line x1="340" y1="148" x2="130" y2="148" class="wif-edge" marker-end="url(#wif-arr)"/>
                 <circle cx="118" cy="148" r="11" fill="#f59e0b"/>
                 <text x="118" y="152" text-anchor="middle" class="wif-s" fill="#fff">2</text>
-                <text x="235" y="140" text-anchor="middle" class="wif-d">signed JWT with claims:</text>
-                <text x="235" y="155" text-anchor="middle" class="wif-tag">repository, ref, workflow, run_id</text>
+                <text x="235" y="140" text-anchor="middle" class="wif-d-conn">signed JWT with claims:</text>
+                <text x="235" y="155" text-anchor="middle" class="wif-tag-conn">repository, ref, workflow, run_id</text>
 
                 <!-- Step 3: workflow presents to STS -->
                 <line x1="130" y1="200" x2="550" y2="200" class="wif-edge" marker-end="url(#wif-arr)"/>
                 <circle cx="118" cy="200" r="11" fill="#059669"/>
                 <text x="118" y="204" text-anchor="middle" class="wif-s" fill="#fff">3</text>
-                <text x="340" y="192" text-anchor="middle" class="wif-d">"exchange this OIDC token for a GCP access token"</text>
-                <text x="340" y="215" text-anchor="middle" class="wif-tag">workloadidentity.exchangeToken</text>
+                <text x="340" y="192" text-anchor="middle" class="wif-d-conn">"exchange this OIDC token for a GCP access token"</text>
+                <text x="340" y="215" text-anchor="middle" class="wif-tag-conn">workloadidentity.exchangeToken</text>
 
                 <!-- Step 4: STS validates and returns -->
                 <rect x="445" y="240" width="210" height="58" rx="4" fill="#fef9c3" stroke="#facc15"/>
@@ -638,15 +652,15 @@
                 <line x1="550" y1="318" x2="130" y2="318" class="wif-edge" marker-end="url(#wif-arr)"/>
                 <circle cx="118" cy="318" r="11" fill="#2563eb"/>
                 <text x="118" y="322" text-anchor="middle" class="wif-s" fill="#fff">4</text>
-                <text x="340" y="310" text-anchor="middle" class="wif-d">1-hour GCP access token, scoped to impersonate</text>
-                <text x="340" y="333" text-anchor="middle" class="wif-tag">csoh-deployer service account</text>
+                <text x="340" y="310" text-anchor="middle" class="wif-d-conn">1-hour GCP access token, scoped to impersonate</text>
+                <text x="340" y="333" text-anchor="middle" class="wif-tag-conn">csoh-deployer service account</text>
 
                 <!-- Step 5: workflow uses token -->
                 <line x1="130" y1="370" x2="760" y2="370" class="wif-edge" marker-end="url(#wif-arr)"/>
                 <circle cx="118" cy="370" r="11" fill="#7c3aed"/>
                 <text x="118" y="374" text-anchor="middle" class="wif-s" fill="#fff">5</text>
-                <text x="445" y="362" text-anchor="middle" class="wif-d">push image, deploy revision (token expires in 1 hour)</text>
-                <text x="445" y="385" text-anchor="middle" class="wif-tag">no stored credential anywhere in this flow</text>
+                <text x="445" y="362" text-anchor="middle" class="wif-d-conn">push image, deploy revision (token expires in 1 hour)</text>
+                <text x="445" y="385" text-anchor="middle" class="wif-tag-conn">no stored credential anywhere in this flow</text>
               </svg>
               <figcaption style="text-align:center;font-size:0.85rem;color:var(--text-muted, #555);margin-top:0.5rem;">How a GitHub Actions run gets a Google Cloud access token without any stored password. The whole exchange takes a few hundred milliseconds at the start of every workflow run; the resulting token expires after one hour.</figcaption>
             </figure>


### PR DESCRIPTION
## Summary

**Reported:** the architecture diagram on /cloud-deployment.html is unreadable.

**Cause:** the inline SVGs hardcoded dark slate colours (`#475569`, `#64748b`) for arrows, lifelines, and connector labels. Inside the boxes that's fine — text sits on a light pastel fill. But the same colours used **outside** boxes blend into the dark page background, and the arrows between boxes effectively disappear.

**Fix:** switch all outside-box visual elements to `currentColor` so they inherit the page text colour and adapt to both modes. Inside-box text keeps its hardcoded dark colour because it sits on light pastel fills (true regardless of mode).

### Architecture diagram

- Arrowhead marker fill → `currentColor`
- `.arch-edge` stroke → `currentColor` (opacity 0.8)
- `.arch-edge-dash` stroke → `currentColor` (opacity 0.45)
- Added `.arch-conn` class for between-box labels (currentColor, 0.75 opacity)
- Switched 4 between-box labels from `.arch-tag` → `.arch-conn`

### WIF sequence diagram

- Arrowhead marker fill → `currentColor`
- `.wif-edge` stroke → `currentColor` (opacity 0.8)
- `.wif-life` stroke → `currentColor` (opacity 0.35) — lifelines
- Added `.wif-d-conn` and `.wif-tag-conn` classes (currentColor, 0.85 / 0.65 opacity)
- Switched 10 between-lifeline labels to the `-conn` variants
- Kept actor-header subtitles and yellow policy-check box labels on the original classes (they're inside boxes)

### Defense-in-depth onion

Already used per-ring accent colours (cyan, blue, purple, etc.) that are readable in both modes — no change needed.

## Test plan

- [x] HTML still validates
- [x] Required CI checks
- [ ] After merge: hard-refresh and confirm both diagrams are readable in light AND dark mode (try toggling the moon/sun in the header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)