### PR TITLE
docs: fix SVG diagrams broken by CSP — use presentation attributes

### DIFF
--- a/cloud-deployment.html
+++ b/cloud-deployment.html
@@ -293,132 +293,128 @@
                     <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
                   </marker>
                 </defs>
-                <style>
-                  /* Box fills + strokes are fixed pastels — they stand
-                     out on both light and dark backgrounds. Text INSIDE
-                     boxes is hardcoded dark because it sits on light
-                     fills. Connector arrows + labels OUTSIDE boxes use
-                     currentColor so they pick up the page's text colour
-                     and stay readable in both light and dark mode. */
-                  .arch-box { fill: #fff; stroke: #475569; stroke-width: 1.5; }
-                  .arch-box-cf  { fill: #fef3c7; stroke: #f59e0b; }
-                  .arch-box-lb  { fill: #dbeafe; stroke: #2563eb; }
-                  .arch-box-run { fill: #ddd6fe; stroke: #7c3aed; }
-                  .arch-box-ci  { fill: #d1fae5; stroke: #059669; }
-                  .arch-box-ar  { fill: #fce7f3; stroke: #db2777; }
-                  .arch-box-log { fill: #e0f2fe; stroke: #0891b2; }
-                  .arch-title { font: 700 13px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: #0f172a; }
-                  .arch-sub   { font: 11px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: #334155; }
-                  .arch-tag   { font: 10px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: #64748b; }
-                  .arch-conn  { font: 10px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: currentColor; opacity: 0.75; }
-                  .arch-edge  { stroke: currentColor; stroke-width: 1.6; fill: none; opacity: 0.8; }
-                  .arch-edge-dash { stroke: currentColor; stroke-width: 1.4; fill: none; stroke-dasharray: 5 4; opacity: 0.45; }
-                </style>
+                <!-- Style note: presentation attributes (fill="..."/stroke="...") are
+                     used directly on each element instead of CSS classes, because the
+                     site's CSP (style-src 'self') blocks inline <style> blocks inside
+                     SVG. Boxes use white fills with colored strokes — the strokes carry
+                     the visual hierarchy and white box bodies stay readable in both
+                     light and dark mode. Connector arrows and between-box labels use
+                     fill/stroke="currentColor" so they pick up the page's text color. -->
 
                 <!-- Browser -->
-                <ellipse cx="200" cy="40" rx="80" ry="22" class="arch-box"/>
-                <text x="200" y="45" text-anchor="middle" class="arch-title">Reader's browser</text>
+                <ellipse cx="200" cy="40" rx="80" ry="22" fill="#fff" stroke="#475569" stroke-width="1.5"/>
+                <text x="200" y="45" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">Reader's browser</text>
 
                 <!-- Arrow to Cloudflare -->
-                <line x1="200" y1="62" x2="200" y2="98" class="arch-edge" marker-end="url(#arr)"/>
-                <text x="210" y="84" class="arch-conn">HTTPS · sees Cloudflare's cert</text>
+                <line x1="200" y1="62" x2="200" y2="98" stroke="currentColor" stroke-width="1.6" opacity="0.8" marker-end="url(#arr)"/>
+                <text x="210" y="84" font-size="10" fill="currentColor" opacity="0.75">HTTPS · sees Cloudflare's cert</text>
 
                 <!-- Cloudflare -->
-                <rect x="40" y="100" width="320" height="100" rx="8" class="arch-box arch-box-cf"/>
-                <text x="200" y="124" text-anchor="middle" class="arch-title">Cloudflare</text>
-                <text x="60" y="148" class="arch-sub">• Global edge cache (CDN)</text>
-                <text x="60" y="166" class="arch-sub">• Blocks known-bad bots, absorbs DDoS</text>
-                <text x="60" y="184" class="arch-sub">• Terminates browser TLS (Universal SSL)</text>
+                <rect x="40" y="100" width="320" height="100" rx="8" fill="#fff" stroke="#f59e0b" stroke-width="2"/>
+                <rect x="40" y="100" width="320" height="6" rx="3" fill="#f59e0b"/>
+                <text x="200" y="128" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">Cloudflare</text>
+                <text x="60" y="150" font-size="11" fill="#334155">• Global edge cache (CDN)</text>
+                <text x="60" y="168" font-size="11" fill="#334155">• Blocks known-bad bots, absorbs DDoS</text>
+                <text x="60" y="186" font-size="11" fill="#334155">• Terminates browser TLS (Universal SSL)</text>
 
                 <!-- Arrow to LB -->
-                <line x1="200" y1="200" x2="200" y2="240" class="arch-edge" marker-end="url(#arr)"/>
-                <text x="210" y="225" class="arch-conn">HTTPS · separate connection</text>
+                <line x1="200" y1="200" x2="200" y2="240" stroke="currentColor" stroke-width="1.6" opacity="0.8" marker-end="url(#arr)"/>
+                <text x="210" y="225" font-size="10" fill="currentColor" opacity="0.75">HTTPS · separate connection</text>
 
                 <!-- Load balancer -->
-                <rect x="40" y="242" width="320" height="130" rx="8" class="arch-box arch-box-lb"/>
-                <text x="200" y="266" text-anchor="middle" class="arch-title">GCP HTTPS Load Balancer</text>
-                <text x="200" y="282" text-anchor="middle" class="arch-tag">anycast IP: 35.190.41.31</text>
-                <text x="60" y="304" class="arch-sub">• Modern TLS only (1.2+, restricted ciphers)</text>
-                <text x="60" y="322" class="arch-sub">• Cloud Armor: OWASP WAF + rate limiting</text>
-                <text x="60" y="340" class="arch-sub">• Cloud CDN: edge cache for static assets</text>
-                <text x="60" y="358" class="arch-sub">• Port 80 → 301 redirect to port 443</text>
+                <rect x="40" y="242" width="320" height="130" rx="8" fill="#fff" stroke="#2563eb" stroke-width="2"/>
+                <rect x="40" y="242" width="320" height="6" rx="3" fill="#2563eb"/>
+                <text x="200" y="270" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">GCP HTTPS Load Balancer</text>
+                <text x="200" y="286" text-anchor="middle" font-size="10" fill="#64748b">anycast IP: 35.190.41.31</text>
+                <text x="60" y="308" font-size="11" fill="#334155">• Modern TLS only (1.2+, restricted ciphers)</text>
+                <text x="60" y="326" font-size="11" fill="#334155">• Cloud Armor: OWASP WAF + rate limiting</text>
+                <text x="60" y="344" font-size="11" fill="#334155">• Cloud CDN: edge cache for static assets</text>
+                <text x="60" y="362" font-size="11" fill="#334155">• Port 80 → 301 redirect to port 443</text>
 
                 <!-- Arrow to Cloud Run -->
-                <line x1="200" y1="372" x2="200" y2="412" class="arch-edge" marker-end="url(#arr)"/>
-                <text x="210" y="397" class="arch-conn">internal-only ingress</text>
+                <line x1="200" y1="372" x2="200" y2="412" stroke="currentColor" stroke-width="1.6" opacity="0.8" marker-end="url(#arr)"/>
+                <text x="210" y="397" font-size="10" fill="currentColor" opacity="0.75">internal-only ingress</text>
 
                 <!-- Cloud Run -->
-                <rect x="40" y="414" width="320" height="140" rx="8" class="arch-box arch-box-run"/>
-                <text x="200" y="438" text-anchor="middle" class="arch-title">Cloud Run service: csoh-site</text>
-                <text x="60" y="460" class="arch-sub">• nginx:1.27-alpine (digest-pinned)</text>
-                <text x="60" y="478" class="arch-sub">• apk upgrade at build time</text>
-                <text x="60" y="496" class="arch-sub">• Sends HSTS, CSP, X-Frame-Options, etc.</text>
-                <text x="60" y="514" class="arch-sub">• Runtime SA has zero IAM permissions</text>
-                <text x="60" y="532" class="arch-sub">• Auto-scales 0 → 10 instances</text>
+                <rect x="40" y="414" width="320" height="140" rx="8" fill="#fff" stroke="#7c3aed" stroke-width="2"/>
+                <rect x="40" y="414" width="320" height="6" rx="3" fill="#7c3aed"/>
+                <text x="200" y="442" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">Cloud Run service: csoh-site</text>
+                <text x="60" y="464" font-size="11" fill="#334155">• nginx:1.27-alpine (digest-pinned)</text>
+                <text x="60" y="482" font-size="11" fill="#334155">• apk upgrade at build time</text>
+                <text x="60" y="500" font-size="11" fill="#334155">• Sends HSTS, CSP, X-Frame-Options, etc.</text>
+                <text x="60" y="518" font-size="11" fill="#334155">• Runtime SA has zero IAM permissions</text>
+                <text x="60" y="536" font-size="11" fill="#334155">• Auto-scales 0 → 10 instances</text>
 
                 <!-- ===== Right column: build/deploy path ===== -->
                 <!-- Header -->
-                <rect x="500" y="20" width="340" height="32" rx="6" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
-                <text x="670" y="40" text-anchor="middle" class="arch-title">Build &amp; deploy path (out of band)</text>
+                <rect x="500" y="20" width="340" height="32" rx="6" fill="#fff" stroke="#94a3b8" stroke-width="1"/>
+                <text x="670" y="40" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">Build &amp; deploy path (out of band)</text>
 
                 <!-- 1. Push -->
-                <rect x="540" y="68" width="260" height="46" rx="6" class="arch-box arch-box-ci"/>
-                <text x="670" y="88" text-anchor="middle" class="arch-title">git push to main</text>
-                <text x="670" y="105" text-anchor="middle" class="arch-sub">triggers gcp-deploy.yml</text>
+                <rect x="540" y="68" width="260" height="46" rx="6" fill="#fff" stroke="#059669" stroke-width="2"/>
+                <rect x="540" y="68" width="260" height="6" rx="3" fill="#059669"/>
+                <text x="670" y="92" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">git push to main</text>
+                <text x="670" y="108" text-anchor="middle" font-size="11" fill="#334155">triggers gcp-deploy.yml</text>
 
-                <line x1="670" y1="114" x2="670" y2="142" class="arch-edge" marker-end="url(#arr)"/>
+                <line x1="670" y1="114" x2="670" y2="142" stroke="currentColor" stroke-width="1.6" opacity="0.8" marker-end="url(#arr)"/>
 
                 <!-- 2. OIDC -->
-                <rect x="540" y="144" width="260" height="56" rx="6" class="arch-box arch-box-ci"/>
-                <text x="670" y="164" text-anchor="middle" class="arch-title">GitHub mints OIDC token</text>
-                <text x="670" y="181" text-anchor="middle" class="arch-sub">claims: repo, branch, workflow</text>
-                <text x="670" y="195" text-anchor="middle" class="arch-tag">no stored credential</text>
+                <rect x="540" y="144" width="260" height="56" rx="6" fill="#fff" stroke="#059669" stroke-width="2"/>
+                <rect x="540" y="144" width="260" height="6" rx="3" fill="#059669"/>
+                <text x="670" y="168" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">GitHub mints OIDC token</text>
+                <text x="670" y="184" text-anchor="middle" font-size="11" fill="#334155">claims: repo, branch, workflow</text>
+                <text x="670" y="197" text-anchor="middle" font-size="10" fill="#64748b">no stored credential</text>
 
-                <line x1="670" y1="200" x2="670" y2="228" class="arch-edge" marker-end="url(#arr)"/>
+                <line x1="670" y1="200" x2="670" y2="228" stroke="currentColor" stroke-width="1.6" opacity="0.8" marker-end="url(#arr)"/>
 
                 <!-- 3. STS exchange -->
-                <rect x="540" y="230" width="260" height="56" rx="6" class="arch-box arch-box-ci"/>
-                <text x="670" y="250" text-anchor="middle" class="arch-title">GCP STS exchange</text>
-                <text x="670" y="267" text-anchor="middle" class="arch-sub">policy: repo == csoh.org only</text>
-                <text x="670" y="281" text-anchor="middle" class="arch-tag">→ 1-hour access token</text>
+                <rect x="540" y="230" width="260" height="56" rx="6" fill="#fff" stroke="#059669" stroke-width="2"/>
+                <rect x="540" y="230" width="260" height="6" rx="3" fill="#059669"/>
+                <text x="670" y="254" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">GCP STS exchange</text>
+                <text x="670" y="270" text-anchor="middle" font-size="11" fill="#334155">policy: repo == csoh.org only</text>
+                <text x="670" y="283" text-anchor="middle" font-size="10" fill="#64748b">→ 1-hour access token</text>
 
-                <line x1="670" y1="286" x2="670" y2="314" class="arch-edge" marker-end="url(#arr)"/>
+                <line x1="670" y1="286" x2="670" y2="314" stroke="currentColor" stroke-width="1.6" opacity="0.8" marker-end="url(#arr)"/>
 
                 <!-- 4. Build + scan -->
-                <rect x="540" y="316" width="260" height="56" rx="6" class="arch-box arch-box-ci"/>
-                <text x="670" y="336" text-anchor="middle" class="arch-title">docker build · Trivy scan</text>
-                <text x="670" y="353" text-anchor="middle" class="arch-sub">fails on HIGH/CRITICAL CVEs</text>
-                <text x="670" y="367" text-anchor="middle" class="arch-tag">scan must pass to push</text>
+                <rect x="540" y="316" width="260" height="56" rx="6" fill="#fff" stroke="#059669" stroke-width="2"/>
+                <rect x="540" y="316" width="260" height="6" rx="3" fill="#059669"/>
+                <text x="670" y="340" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">docker build · Trivy scan</text>
+                <text x="670" y="356" text-anchor="middle" font-size="11" fill="#334155">fails on HIGH/CRITICAL CVEs</text>
+                <text x="670" y="369" text-anchor="middle" font-size="10" fill="#64748b">scan must pass to push</text>
 
-                <line x1="670" y1="372" x2="670" y2="400" class="arch-edge" marker-end="url(#arr)"/>
+                <line x1="670" y1="372" x2="670" y2="400" stroke="currentColor" stroke-width="1.6" opacity="0.8" marker-end="url(#arr)"/>
 
                 <!-- 5. Artifact Registry -->
-                <rect x="540" y="402" width="260" height="56" rx="6" class="arch-box arch-box-ar"/>
-                <text x="670" y="422" text-anchor="middle" class="arch-title">Artifact Registry</text>
-                <text x="670" y="439" text-anchor="middle" class="arch-sub">immutable hash-based tag</text>
-                <text x="670" y="453" text-anchor="middle" class="arch-tag">tag can never be overwritten</text>
+                <rect x="540" y="402" width="260" height="56" rx="6" fill="#fff" stroke="#db2777" stroke-width="2"/>
+                <rect x="540" y="402" width="260" height="6" rx="3" fill="#db2777"/>
+                <text x="670" y="426" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">Artifact Registry</text>
+                <text x="670" y="442" text-anchor="middle" font-size="11" fill="#334155">immutable hash-based tag</text>
+                <text x="670" y="455" text-anchor="middle" font-size="10" fill="#64748b">tag can never be overwritten</text>
 
-                <line x1="670" y1="458" x2="670" y2="486" class="arch-edge" marker-end="url(#arr)"/>
+                <line x1="670" y1="458" x2="670" y2="486" stroke="currentColor" stroke-width="1.6" opacity="0.8" marker-end="url(#arr)"/>
 
                 <!-- 6. Deploy -->
-                <rect x="540" y="488" width="260" height="56" rx="6" class="arch-box arch-box-run"/>
-                <text x="670" y="508" text-anchor="middle" class="arch-title">gcloud run deploy</text>
-                <text x="670" y="525" text-anchor="middle" class="arch-sub">new revision pinned to hash</text>
-                <text x="670" y="539" text-anchor="middle" class="arch-tag">rollback = 1 CLI command</text>
+                <rect x="540" y="488" width="260" height="56" rx="6" fill="#fff" stroke="#7c3aed" stroke-width="2"/>
+                <rect x="540" y="488" width="260" height="6" rx="3" fill="#7c3aed"/>
+                <text x="670" y="512" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">gcloud run deploy</text>
+                <text x="670" y="528" text-anchor="middle" font-size="11" fill="#334155">new revision pinned to hash</text>
+                <text x="670" y="541" text-anchor="middle" font-size="10" fill="#64748b">rollback = 1 CLI command</text>
 
                 <!-- Cross-arrow: deploy → Cloud Run service -->
-                <path d="M 540 516 Q 460 516 410 484" class="arch-edge-dash" marker-end="url(#arr)"/>
-                <text x="430" y="510" class="arch-conn" text-anchor="end">configures →</text>
+                <path d="M 540 516 Q 460 516 410 484" stroke="currentColor" stroke-width="1.4" stroke-dasharray="5 4" fill="none" opacity="0.45" marker-end="url(#arr)"/>
+                <text x="430" y="510" font-size="10" fill="currentColor" opacity="0.75" text-anchor="end">configures →</text>
 
                 <!-- ===== Bottom: logging ===== -->
-                <rect x="100" y="608" width="680" height="80" rx="8" class="arch-box arch-box-log"/>
-                <text x="440" y="632" text-anchor="middle" class="arch-title">Cloud Logging sink → 400-day retention bucket</text>
-                <text x="440" y="654" text-anchor="middle" class="arch-sub">Cloud Armor decisions · LB 4xx/5xx · IAM admin activity · audit logs</text>
-                <text x="440" y="672" text-anchor="middle" class="arch-tag">background, no extra config</text>
+                <rect x="100" y="608" width="680" height="80" rx="8" fill="#fff" stroke="#0891b2" stroke-width="2"/>
+                <rect x="100" y="608" width="680" height="6" rx="3" fill="#0891b2"/>
+                <text x="440" y="636" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">Cloud Logging sink → 400-day retention bucket</text>
+                <text x="440" y="656" text-anchor="middle" font-size="11" fill="#334155">Cloud Armor decisions · LB 4xx/5xx · IAM admin activity · audit logs</text>
+                <text x="440" y="672" text-anchor="middle" font-size="10" fill="#64748b">background, no extra config</text>
 
                 <!-- Arrows from LB and from Cloud Run + STS exchange to logging (dashed = always-on observation) -->
-                <path d="M 200 554 Q 200 580 440 608" class="arch-edge-dash"/>
-                <path d="M 670 544 Q 670 580 440 608" class="arch-edge-dash"/>
+                <path d="M 200 554 Q 200 580 440 608" stroke="currentColor" stroke-width="1.4" stroke-dasharray="5 4" fill="none" opacity="0.45"/>
+                <path d="M 670 544 Q 670 580 440 608" stroke="currentColor" stroke-width="1.4" stroke-dasharray="5 4" fill="none" opacity="0.45"/>
               </svg>
               <figcaption style="text-align:center;font-size:0.85rem;color:var(--text-muted, #555);margin-top:0.5rem;">The full request path on the left, the build &amp; deploy path on the right, the logging pipeline running underneath both. Every box and arrow is config in <a href="https://github.com/CloudSecurityOfficeHours/csoh.org/tree/main/infra/terraform" target="_blank" rel="noopener noreferrer">infra/terraform/</a>.</figcaption>
             </figure>
@@ -578,89 +574,75 @@
                     <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
                   </marker>
                 </defs>
-                <style>
-                  /* Same dark/light strategy as the architecture
-                     diagram: pastel box fills + dark text inside boxes
-                     stay constant; lifelines, arrows and between-actor
-                     labels use currentColor so they pick up the page
-                     text colour. */
-                  .wif-actor   { fill: #fff; stroke: #334155; stroke-width: 1.5; }
-                  .wif-gha     { fill: #d1fae5; stroke: #059669; }
-                  .wif-gh-id   { fill: #fef3c7; stroke: #f59e0b; }
-                  .wif-sts     { fill: #dbeafe; stroke: #2563eb; }
-                  .wif-gcp     { fill: #ddd6fe; stroke: #7c3aed; }
-                  .wif-h       { font: 700 13px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: #0f172a; }
-                  .wif-s       { font: 700 11px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: #0f172a; }
-                  .wif-d       { font: 11px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: #475569; }
-                  .wif-tag     { font: 10px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: #64748b; }
-                  .wif-d-conn  { font: 11px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: currentColor; opacity: 0.85; }
-                  .wif-tag-conn{ font: 10px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif; fill: currentColor; opacity: 0.65; }
-                  .wif-edge    { stroke: currentColor; stroke-width: 1.6; fill: none; opacity: 0.8; }
-                  .wif-life    { stroke: currentColor; stroke-width: 1; stroke-dasharray: 3 3; opacity: 0.35; }
-                </style>
+                <!-- Actor header boxes: white fill + colored stroke + colored top-bar
+                     for visual distinction (same pattern as architecture diagram). -->
+                <rect x="40"  y="20" width="180" height="48" rx="6" fill="#fff" stroke="#059669" stroke-width="2"/>
+                <rect x="40"  y="20" width="180" height="6"  rx="3" fill="#059669"/>
+                <text x="130" y="44" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">GitHub Actions</text>
+                <text x="130" y="60" text-anchor="middle" font-size="11" fill="#475569">runner (the workflow)</text>
 
-                <!-- Actor headers -->
-                <rect x="40"  y="20" width="180" height="48" rx="6" class="wif-actor wif-gha"/>
-                <text x="130" y="42" text-anchor="middle" class="wif-h">GitHub Actions</text>
-                <text x="130" y="58" text-anchor="middle" class="wif-d">runner (the workflow)</text>
+                <rect x="260" y="20" width="160" height="48" rx="6" fill="#fff" stroke="#f59e0b" stroke-width="2"/>
+                <rect x="260" y="20" width="160" height="6"  rx="3" fill="#f59e0b"/>
+                <text x="340" y="44" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">GitHub Identity</text>
+                <text x="340" y="60" text-anchor="middle" font-size="11" fill="#475569">OIDC issuer</text>
 
-                <rect x="260" y="20" width="160" height="48" rx="6" class="wif-actor wif-gh-id"/>
-                <text x="340" y="42" text-anchor="middle" class="wif-h">GitHub Identity</text>
-                <text x="340" y="58" text-anchor="middle" class="wif-d">OIDC issuer</text>
+                <rect x="460" y="20" width="180" height="48" rx="6" fill="#fff" stroke="#2563eb" stroke-width="2"/>
+                <rect x="460" y="20" width="180" height="6"  rx="3" fill="#2563eb"/>
+                <text x="550" y="44" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">Google Cloud STS</text>
+                <text x="550" y="60" text-anchor="middle" font-size="11" fill="#475569">Security Token Service</text>
 
-                <rect x="460" y="20" width="180" height="48" rx="6" class="wif-actor wif-sts"/>
-                <text x="550" y="42" text-anchor="middle" class="wif-h">Google Cloud STS</text>
-                <text x="550" y="58" text-anchor="middle" class="wif-d">Security Token Service</text>
+                <rect x="680" y="20" width="160" height="48" rx="6" fill="#fff" stroke="#7c3aed" stroke-width="2"/>
+                <rect x="680" y="20" width="160" height="6"  rx="3" fill="#7c3aed"/>
+                <text x="760" y="44" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">GCP resources</text>
+                <text x="760" y="60" text-anchor="middle" font-size="11" fill="#475569">Cloud Run, AR, etc.</text>
 
-                <rect x="680" y="20" width="160" height="48" rx="6" class="wif-actor wif-gcp"/>
-                <text x="760" y="42" text-anchor="middle" class="wif-h">GCP resources</text>
-                <text x="760" y="58" text-anchor="middle" class="wif-d">Cloud Run, AR, etc.</text>
-
-                <!-- Lifelines -->
-                <line x1="130" y1="68" x2="130" y2="400" class="wif-life"/>
-                <line x1="340" y1="68" x2="340" y2="400" class="wif-life"/>
-                <line x1="550" y1="68" x2="550" y2="400" class="wif-life"/>
-                <line x1="760" y1="68" x2="760" y2="400" class="wif-life"/>
+                <!-- Lifelines (currentColor adapts to mode) -->
+                <line x1="130" y1="68" x2="130" y2="400" stroke="currentColor" stroke-width="1" stroke-dasharray="3 3" opacity="0.35"/>
+                <line x1="340" y1="68" x2="340" y2="400" stroke="currentColor" stroke-width="1" stroke-dasharray="3 3" opacity="0.35"/>
+                <line x1="550" y1="68" x2="550" y2="400" stroke="currentColor" stroke-width="1" stroke-dasharray="3 3" opacity="0.35"/>
+                <line x1="760" y1="68" x2="760" y2="400" stroke="currentColor" stroke-width="1" stroke-dasharray="3 3" opacity="0.35"/>
 
                 <!-- Step 1: workflow asks for OIDC token -->
-                <line x1="130" y1="100" x2="340" y2="100" class="wif-edge" marker-end="url(#wif-arr)"/>
+                <line x1="130" y1="100" x2="340" y2="100" stroke="currentColor" stroke-width="1.6" opacity="0.8" marker-end="url(#wif-arr)"/>
                 <circle cx="118" cy="100" r="11" fill="#059669"/>
-                <text x="118" y="104" text-anchor="middle" class="wif-s" fill="#fff">1</text>
-                <text x="235" y="92"  text-anchor="middle" class="wif-d-conn">"give me an OIDC token for this run"</text>
-                <text x="235" y="115" text-anchor="middle" class="wif-tag-conn">permissions: id-token: write</text>
+                <text x="118" y="104" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">1</text>
+                <text x="235" y="92"  text-anchor="middle" font-size="11" fill="currentColor" opacity="0.85">"give me an OIDC token for this run"</text>
+                <text x="235" y="115" text-anchor="middle" font-size="10" fill="currentColor" opacity="0.65">permissions: id-token: write</text>
 
                 <!-- Step 2: GitHub returns OIDC token -->
-                <line x1="340" y1="148" x2="130" y2="148" class="wif-edge" marker-end="url(#wif-arr)"/>
+                <line x1="340" y1="148" x2="130" y2="148" stroke="currentColor" stroke-width="1.6" opacity="0.8" marker-end="url(#wif-arr)"/>
                 <circle cx="118" cy="148" r="11" fill="#f59e0b"/>
-                <text x="118" y="152" text-anchor="middle" class="wif-s" fill="#fff">2</text>
-                <text x="235" y="140" text-anchor="middle" class="wif-d-conn">signed JWT with claims:</text>
-                <text x="235" y="155" text-anchor="middle" class="wif-tag-conn">repository, ref, workflow, run_id</text>
+                <text x="118" y="152" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">2</text>
+                <text x="235" y="140" text-anchor="middle" font-size="11" fill="currentColor" opacity="0.85">signed JWT with claims:</text>
+                <text x="235" y="155" text-anchor="middle" font-size="10" fill="currentColor" opacity="0.65">repository, ref, workflow, run_id</text>
 
                 <!-- Step 3: workflow presents to STS -->
-                <line x1="130" y1="200" x2="550" y2="200" class="wif-edge" marker-end="url(#wif-arr)"/>
+                <line x1="130" y1="200" x2="550" y2="200" stroke="currentColor" stroke-width="1.6" opacity="0.8" marker-end="url(#wif-arr)"/>
                 <circle cx="118" cy="200" r="11" fill="#059669"/>
-                <text x="118" y="204" text-anchor="middle" class="wif-s" fill="#fff">3</text>
-                <text x="340" y="192" text-anchor="middle" class="wif-d-conn">"exchange this OIDC token for a GCP access token"</text>
-                <text x="340" y="215" text-anchor="middle" class="wif-tag-conn">workloadidentity.exchangeToken</text>
+                <text x="118" y="204" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">3</text>
+                <text x="340" y="192" text-anchor="middle" font-size="11" fill="currentColor" opacity="0.85">"exchange this OIDC token for a GCP access token"</text>
+                <text x="340" y="215" text-anchor="middle" font-size="10" fill="currentColor" opacity="0.65">workloadidentity.exchangeToken</text>
 
-                <!-- Step 4: STS validates and returns -->
-                <rect x="445" y="240" width="210" height="58" rx="4" fill="#fef9c3" stroke="#facc15"/>
-                <text x="550" y="258" text-anchor="middle" class="wif-s">policy check</text>
-                <text x="550" y="275" text-anchor="middle" class="wif-d">assertion.repository ==</text>
-                <text x="550" y="290" text-anchor="middle" class="wif-tag">'CloudSecurityOfficeHours/csoh.org'</text>
+                <!-- Step 4: STS validates and returns. Yellow rect is the policy-check
+                     callout — keeps a saturated yellow fill so it pops as a distinct
+                     decision step in both light and dark mode. -->
+                <rect x="445" y="240" width="210" height="58" rx="4" fill="#fef08a" stroke="#ca8a04" stroke-width="1.5"/>
+                <text x="550" y="258" text-anchor="middle" font-size="11" font-weight="700" fill="#422006">policy check</text>
+                <text x="550" y="275" text-anchor="middle" font-size="11" fill="#422006">assertion.repository ==</text>
+                <text x="550" y="290" text-anchor="middle" font-size="10" fill="#422006">'CloudSecurityOfficeHours/csoh.org'</text>
 
-                <line x1="550" y1="318" x2="130" y2="318" class="wif-edge" marker-end="url(#wif-arr)"/>
+                <line x1="550" y1="318" x2="130" y2="318" stroke="currentColor" stroke-width="1.6" opacity="0.8" marker-end="url(#wif-arr)"/>
                 <circle cx="118" cy="318" r="11" fill="#2563eb"/>
-                <text x="118" y="322" text-anchor="middle" class="wif-s" fill="#fff">4</text>
-                <text x="340" y="310" text-anchor="middle" class="wif-d-conn">1-hour GCP access token, scoped to impersonate</text>
-                <text x="340" y="333" text-anchor="middle" class="wif-tag-conn">csoh-deployer service account</text>
+                <text x="118" y="322" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">4</text>
+                <text x="340" y="310" text-anchor="middle" font-size="11" fill="currentColor" opacity="0.85">1-hour GCP access token, scoped to impersonate</text>
+                <text x="340" y="333" text-anchor="middle" font-size="10" fill="currentColor" opacity="0.65">csoh-deployer service account</text>
 
                 <!-- Step 5: workflow uses token -->
-                <line x1="130" y1="370" x2="760" y2="370" class="wif-edge" marker-end="url(#wif-arr)"/>
+                <line x1="130" y1="370" x2="760" y2="370" stroke="currentColor" stroke-width="1.6" opacity="0.8" marker-end="url(#wif-arr)"/>
                 <circle cx="118" cy="370" r="11" fill="#7c3aed"/>
-                <text x="118" y="374" text-anchor="middle" class="wif-s" fill="#fff">5</text>
-                <text x="445" y="362" text-anchor="middle" class="wif-d-conn">push image, deploy revision (token expires in 1 hour)</text>
-                <text x="445" y="385" text-anchor="middle" class="wif-tag-conn">no stored credential anywhere in this flow</text>
+                <text x="118" y="374" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">5</text>
+                <text x="445" y="362" text-anchor="middle" font-size="11" fill="currentColor" opacity="0.85">push image, deploy revision (token expires in 1 hour)</text>
+                <text x="445" y="385" text-anchor="middle" font-size="10" fill="currentColor" opacity="0.65">no stored credential anywhere in this flow</text>
               </svg>
               <figcaption style="text-align:center;font-size:0.85rem;color:var(--text-muted, #555);margin-top:0.5rem;">How a GitHub Actions run gets a Google Cloud access token without any stored password. The whole exchange takes a few hundred milliseconds at the start of every workflow run; the resulting token expires after one hour.</figcaption>
             </figure>


### PR DESCRIPTION
## What was wrong

The architecture diagram and WIF flow diagram on `/cloud-deployment.html` were rendering with **solid black box fills and invisible inside-box text** in dark mode (and light mode wasn't right either, just less obviously bad).

**Root cause:** the SVGs used inline `<style>` blocks with CSS classes (`.arch-box { fill: #fff }` etc.). The site's strict CSP — `style-src 'self'` with no `'unsafe-inline'` or nonce — **blocks inline `<style>` elements, including ones inside SVG**. With the rules not applied, every `<rect>` fell back to SVG's default fill, which is `black`.

The previous "dark-mode fix" PR added `currentColor` to arrows/labels via the same blocked `<style>` block, so it never actually shipped. The labels happened to render with the page's default text color anyway, masking how broken the box fills were until you saw it on a dark theme and it was unmistakable.

## The fix

Convert all inline `<style>` rules to per-element **presentation attributes** (`fill="..."`, `stroke="..."`, `font-size="..."`) — the pattern `github-actions.html` already uses on its working SVGs.

While rewriting, also tweaked the visual style:

- **Box bodies**: white fill (`#fff`) with a 2px colored stroke and a colored top-bar strip per box for hierarchy. Reads well on both light and dark backgrounds (white-on-dark = clear contrast; white-on-light is just normal).
- **Connector arrows + between-box labels**: `stroke`/`fill="currentColor"` with opacity, so they pick up the page's text color in both modes.
- **Inside-box text**: hardcoded dark (`#0f172a`, `#334155`, `#64748b`) on the white box bodies — readable in both modes.
- **WIF policy-check callout**: kept as a saturated yellow (`#fef08a`) because its entire purpose is to *pop* as a distinct "policy is checked here" step.

## Test plan

- [x] HTML still validates
- [x] Required CI checks
- [ ] After merge: hard-refresh and verify both diagrams render correctly in light AND dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)