### PR TITLE
ci: make container image push idempotent on rerun

### DIFF
--- a/.github/workflows/gcp-deploy.yml
+++ b/.github/workflows/gcp-deploy.yml
@@ -134,8 +134,22 @@ jobs:
             --no-progress \
             "${{ steps.tag.outputs.image }}"
 
-      - name: Push container image
-        run: docker push "${{ steps.tag.outputs.image }}"
+      # Artifact Registry has immutable_tags=true (a supply-chain control —
+      # see Layer 5 of cloud-deployment.html), so re-pushing a tag fails.
+      # That's the desired behavior for tampering, but it makes a workflow
+      # rerun impossible whenever an earlier run pushed the image and then
+      # failed at a later step (e.g. deploy or CDN invalidate). We make
+      # push idempotent by checking AR first; the locally-built image was
+      # already Trivy-scanned this run, and the AR image was scanned on
+      # the original run, so either way the deployed bytes are scanned.
+      - name: Push container image (skip if already in registry)
+        run: |
+          set -euo pipefail
+          if gcloud artifacts docker images describe "${{ steps.tag.outputs.image }}" --quiet >/dev/null 2>&1; then
+            echo "Image already exists in Artifact Registry — skipping push (idempotent rerun)."
+          else
+            docker push "${{ steps.tag.outputs.image }}"
+          fi
 
       - name: Deploy to Cloud Run
         run: |


### PR DESCRIPTION
## Summary
Patches the deploy workflow so that re-running a failed run after the push step succeeded doesn't fail at the push step the second time.

## Why now
PR #677 hit this exact trap. The first run pushed the image to Artifact Registry, then failed at the new "Invalidate Cloud CDN" step (IAM hadn't been applied yet). Once IAM was fixed and the run was re-triggered, the rerun failed at the push step with `manifest invalid: cannot update tag … The repository has enabled tag immutability` — because Artifact Registry has `immutable_tags=true`. That's a supply-chain control we *want* to keep (Layer 5 of cloud-deployment.html); re-pushes from a fresh deploy or a malicious actor still fail closed. We just need a graceful rerun path.

## How
The push step now checks Artifact Registry first via `gcloud artifacts docker images describe`. If the tag is already present, push is skipped and the run continues to deploy + invalidate. The Trivy scan still runs against the locally-built image every time.

## Why this doesn't weaken the supply-chain story
- Tag immutability is unchanged — AR still rejects any actual *overwrite* attempt
- The image that gets deployed was Trivy-scanned in *some* successful run; the rerun also scans the locally-built image before the skip-or-push decision
- The skip path only fires when the exact same tag (commit SHA) is already present, which can only happen on a workflow rerun of the same commit

## Test plan
- [ ] CI passes (actionlint, yamllint)
- [ ] After merge, the deploy workflow runs end-to-end against a fresh commit (push happens normally because the tag is new)
- [ ] If we ever rerun this same merge, the push step skips with "Image already exists … skipping push (idempotent rerun)" and the deploy + invalidate steps complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)