### PR TITLE
fix(iam): add compute.urlMaps.get to CDN invalidator custom role

### DIFF
--- a/infra/terraform/service_accounts.tf
+++ b/infra/terraform/service_accounts.tf
@@ -37,16 +37,22 @@ resource "google_service_account_iam_member" "deployer_act_as_runtime" {
   member             = "serviceAccount:${google_service_account.deployer.email}"
 }
 
-# Narrow custom role: just the one permission needed to invalidate the
-# Cloud CDN cache after a deploy. Predefined alternatives (loadBalancerAdmin,
-# urlMapAdmin) include rights to *modify* the URL map and CDN policy, which
-# the deployer has no business doing — those changes belong in Terraform.
+# Narrow custom role: the two permissions needed to invalidate the Cloud
+# CDN cache after a deploy. `gcloud compute url-maps invalidate-cdn-cache`
+# does an implicit GET on the URL map before issuing the invalidation, so
+# both `get` and `invalidateCache` are required. Predefined alternatives
+# (loadBalancerAdmin, urlMapAdmin) include rights to *modify* the URL map
+# and CDN policy, which the deployer has no business doing — those
+# changes belong in Terraform.
 resource "google_project_iam_custom_role" "cdn_cache_invalidator" {
   project     = var.project_id
   role_id     = "csohCdnCacheInvalidator"
   title       = "CSOH Cloud CDN Cache Invalidator"
-  description = "Single permission needed to invalidate Cloud CDN entries after a Cloud Run deploy."
-  permissions = ["compute.urlMaps.invalidateCache"]
+  description = "Permissions needed to invalidate Cloud CDN entries after a Cloud Run deploy."
+  permissions = [
+    "compute.urlMaps.get",
+    "compute.urlMaps.invalidateCache",
+  ]
 }
 
 resource "google_project_iam_member" "deployer_cdn_invalidator" {


### PR DESCRIPTION
## Summary
Adds `compute.urlMaps.get` to the `csohCdnCacheInvalidator` custom role. The `gcloud compute url-maps invalidate-cdn-cache` command does an implicit GET on the URL map before issuing the invalidate call, so both permissions are required. The first version of the role only had `invalidateCache`, which broke the first deploy that exercised the new workflow step (run [25608435392](https://github.com/CloudSecurityOfficeHours/csoh.org/actions/runs/25608435392)).

## Why this is still a narrow role
Predefined alternatives (`loadBalancerAdmin`, `urlMapAdmin`) include modify rights on the URL map and CDN policy, which the deployer has no business doing — those changes belong in Terraform. A read + invalidate combination is exactly what's needed and nothing more.

## Pre-merge requirement
`terraform apply` from `infra/terraform/` after merging this change. Until that runs, the next deploy will fail at the invalidate step with the same `Required 'compute.urlMaps.get' permission` error.

## Test plan
- [ ] After terraform apply, `gcloud iam roles describe csohCdnCacheInvalidator --project csoh-org-495800` lists both `compute.urlMaps.get` and `compute.urlMaps.invalidateCache`
- [ ] Trigger a deploy (any commit to main, or `gh workflow run gcp-deploy.yml`) and confirm the "Invalidate Cloud CDN cache" step succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)