### PR TITLE
feat(cloud-deployment): add GCP logo to hero

### DIFF
--- a/403.html
+++ b/403.html
@@ -11,7 +11,7 @@
     <link rel="manifest" href="/manifest.json">
     <link rel="author" type="text/plain" href="/humans.txt">
     <meta name="theme-color" content="#2c3e50">
-    <link rel="stylesheet" href="/style.css?v=00c7245c" integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="stylesheet" href="/style.css?v=ab65700f" integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
   <noscript><style>.js-enabled header nav{display:block !important}</style></noscript>
 </head>

--- a/404.html
+++ b/404.html
@@ -11,7 +11,7 @@
     <link rel="manifest" href="/manifest.json">
     <link rel="author" type="text/plain" href="/humans.txt">
     <meta name="theme-color" content="#2c3e50">
-    <link rel="stylesheet" href="/style.css?v=00c7245c" integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="stylesheet" href="/style.css?v=ab65700f" integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
 
   <noscript><style>.js-enabled header nav{display:block !important}</style></noscript>

--- a/about-shawn-nunley.html
+++ b/about-shawn-nunley.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/ai-learning.html
+++ b/ai-learning.html
@@ -36,10 +36,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/breach-timeline.html
+++ b/breach-timeline.html
@@ -35,10 +35,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
     <link rel="stylesheet" href="breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">

--- a/breaches/capital-one.html
+++ b/breaches/capital-one.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
     <link rel="stylesheet" href="breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">

--- a/breaches/lastpass.html
+++ b/breaches/lastpass.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
     <link rel="stylesheet" href="breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">

--- a/breaches/microsoft-sas-leak.html
+++ b/breaches/microsoft-sas-leak.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
     <link rel="stylesheet" href="breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">

--- a/breaches/mitnick-novell.html
+++ b/breaches/mitnick-novell.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
     <link rel="stylesheet" href="breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">

--- a/breaches/promptware.html
+++ b/breaches/promptware.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
     <link rel="stylesheet" href="breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">

--- a/breaches/scattered-spider-mgm.html
+++ b/breaches/scattered-spider-mgm.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
     <link rel="stylesheet" href="breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">

--- a/breaches/snowflake-unc5537.html
+++ b/breaches/snowflake-unc5537.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
     <link rel="stylesheet" href="breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">

--- a/breaches/solarwinds.html
+++ b/breaches/solarwinds.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
     <link rel="stylesheet" href="breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">

--- a/breaches/storm-0558.html
+++ b/breaches/storm-0558.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
     <link rel="stylesheet" href="breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">

--- a/breaches/uber.html
+++ b/breaches/uber.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
     <link rel="stylesheet" href="breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">

--- a/chat-resources.html
+++ b/chat-resources.html
@@ -12,7 +12,7 @@
     <link rel="manifest" href="/manifest.json">
     <link rel="author" type="text/plain" href="/humans.txt">
     <meta name="theme-color" content="#2c3e50">
-    <link rel="stylesheet" href="/style.css?v=00c7245c" integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="stylesheet" href="/style.css?v=ab65700f" integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
   <noscript><style>.js-enabled header nav{display:block !important}</style></noscript>
 </head>
 

--- a/cloud-deployment.html
+++ b/cloud-deployment.html
@@ -33,10 +33,10 @@
     <link rel="preconnect" href="https://github.com" crossorigin>
     <link rel="dns-prefetch" href="https://github.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {
@@ -163,6 +163,24 @@
     <section class="hero">
       <div class="hero-inner">
         <div class="hero-text">
+          <svg class="hero-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 220" role="img" aria-label="Google Cloud Platform" focusable="false">
+            <g>
+              <path d="M110 110 L65 32 L155 32 Z" fill="#4285F4"/>
+              <path d="M110 110 L155 32 L200 110 L155 188 Z" fill="#EA4335"/>
+              <path d="M110 110 L155 188 L65 188 L20 110 L65 32 Z" fill="#F9AB00"/>
+              <circle cx="110" cy="110" r="24" fill="#F1F3F4"/>
+              <circle cx="65"  cy="32"  r="5" fill="#ffffff"/>
+              <circle cx="155" cy="32"  r="5" fill="#ffffff"/>
+              <circle cx="200" cy="110" r="5" fill="#ffffff"/>
+              <circle cx="155" cy="188" r="5" fill="#ffffff"/>
+              <circle cx="65"  cy="188" r="5" fill="#ffffff"/>
+              <circle cx="20"  cy="110" r="5" fill="#ffffff"/>
+            </g>
+            <g fill="#5F6368">
+              <text x="240" y="118" font-family="Georgia, 'Times New Roman', serif" font-size="76" font-weight="400">Google</text>
+              <text x="240" y="186" font-family="'Helvetica Neue', Arial, sans-serif" font-size="52" font-weight="300" letter-spacing="0.5">Cloud Platform</text>
+            </g>
+          </svg>
           <h1>How We Deploy csoh.org to GCP</h1>
           <p>A plain-English tour of how we host this site — eight layers of security, what each one defends against, and the actual config files that make it work. Written for anyone who's ever deployed a website and wondered what a "real" cloud setup looks like underneath.</p>
           <div class="cta-buttons">

--- a/cloud-security-best-practices.html
+++ b/cloud-security-best-practices.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/cloud-security-careers.html
+++ b/cloud-security-careers.html
@@ -36,10 +36,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/cloud-security-certifications.html
+++ b/cloud-security-certifications.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/cloud-security-degree-programs.html
+++ b/cloud-security-degree-programs.html
@@ -36,10 +36,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/cloud-security-home-lab.html
+++ b/cloud-security-home-lab.html
@@ -36,10 +36,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/cloud-security-portfolio-projects.html
+++ b/cloud-security-portfolio-projects.html
@@ -36,10 +36,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/cloud-security-reading-list.html
+++ b/cloud-security-reading-list.html
@@ -36,10 +36,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -35,10 +35,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
   <noscript><style>.js-enabled header nav{display:block !important}</style></noscript>
 </head>
 

--- a/community.html
+++ b/community.html
@@ -36,10 +36,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/conferences.html
+++ b/conferences.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/contribute-resources.html
+++ b/contribute-resources.html
@@ -38,10 +38,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
 
 

--- a/contribute.html
+++ b/contribute.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
 
 

--- a/cspm-vs-cnapp.html
+++ b/cspm-vs-cnapp.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/ctfs.html
+++ b/ctfs.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <style>
         /* Wiz Championship calendar layout */

--- a/faq.html
+++ b/faq.html
@@ -37,10 +37,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/github-actions.html
+++ b/github-actions.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/glossary.html
+++ b/glossary.html
@@ -37,10 +37,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/index.html
+++ b/index.html
@@ -44,11 +44,11 @@
     imagesrcset="/img/photos/homepage-team-800.webp 800w, /img/photos/homepage-team-1200.webp 1200w, /img/photos/homepage-team.webp 1880w"
     imagesizes="(max-width: 768px) 100vw, (max-width: 1200px) 1136px, 1136px" fetchpriority="high">
 
-  <link rel="preload" href="/style.css?v=00c7245c" as="style"
-    integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+  <link rel="preload" href="/style.css?v=ab65700f" as="style"
+    integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
-  <link rel="stylesheet" href="/style.css?v=00c7245c"
-    integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+  <link rel="stylesheet" href="/style.css?v=ab65700f"
+    integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
   <!-- Structured Data for SEO -->
   <script type="application/ld+json">

--- a/kevin-mitnick.html
+++ b/kevin-mitnick.html
@@ -92,10 +92,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
   <noscript><style>.js-enabled header nav{display:block !important}</style></noscript>
 </head>

--- a/learning-path.html
+++ b/learning-path.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings.html
+++ b/meetings.html
@@ -35,10 +35,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-03-01.html
+++ b/meetings/2024-03-01.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-04-05.html
+++ b/meetings/2024-04-05.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-04-26.html
+++ b/meetings/2024-04-26.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-05-10.html
+++ b/meetings/2024-05-10.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-07-12.html
+++ b/meetings/2024-07-12.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-07-19.html
+++ b/meetings/2024-07-19.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-07-26.html
+++ b/meetings/2024-07-26.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-08-09.html
+++ b/meetings/2024-08-09.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-08-23.html
+++ b/meetings/2024-08-23.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-08-30.html
+++ b/meetings/2024-08-30.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-09-27.html
+++ b/meetings/2024-09-27.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-10-04.html
+++ b/meetings/2024-10-04.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-10-11.html
+++ b/meetings/2024-10-11.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-10-18.html
+++ b/meetings/2024-10-18.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-10-25.html
+++ b/meetings/2024-10-25.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-11-01.html
+++ b/meetings/2024-11-01.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-11-08.html
+++ b/meetings/2024-11-08.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-11-15.html
+++ b/meetings/2024-11-15.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-11-22.html
+++ b/meetings/2024-11-22.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-11-29.html
+++ b/meetings/2024-11-29.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-12-13.html
+++ b/meetings/2024-12-13.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-12-20.html
+++ b/meetings/2024-12-20.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2024-12-27.html
+++ b/meetings/2024-12-27.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-01-03.html
+++ b/meetings/2025-01-03.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-01-10.html
+++ b/meetings/2025-01-10.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-01-17.html
+++ b/meetings/2025-01-17.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-01-24.html
+++ b/meetings/2025-01-24.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-01-31.html
+++ b/meetings/2025-01-31.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-02-07.html
+++ b/meetings/2025-02-07.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-02-14.html
+++ b/meetings/2025-02-14.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-02-21.html
+++ b/meetings/2025-02-21.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-02-28.html
+++ b/meetings/2025-02-28.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-03-07.html
+++ b/meetings/2025-03-07.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-03-14.html
+++ b/meetings/2025-03-14.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-03-21.html
+++ b/meetings/2025-03-21.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-03-28.html
+++ b/meetings/2025-03-28.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-04-04.html
+++ b/meetings/2025-04-04.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-04-11.html
+++ b/meetings/2025-04-11.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-04-18.html
+++ b/meetings/2025-04-18.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-04-25.html
+++ b/meetings/2025-04-25.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-05-02.html
+++ b/meetings/2025-05-02.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-05-09.html
+++ b/meetings/2025-05-09.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-05-16.html
+++ b/meetings/2025-05-16.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-05-23.html
+++ b/meetings/2025-05-23.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-05-30.html
+++ b/meetings/2025-05-30.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-06-06.html
+++ b/meetings/2025-06-06.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-06-13.html
+++ b/meetings/2025-06-13.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-06-20.html
+++ b/meetings/2025-06-20.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-06-27.html
+++ b/meetings/2025-06-27.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-07-04.html
+++ b/meetings/2025-07-04.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-07-11.html
+++ b/meetings/2025-07-11.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-07-18.html
+++ b/meetings/2025-07-18.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-07-25.html
+++ b/meetings/2025-07-25.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-08-01.html
+++ b/meetings/2025-08-01.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-08-08.html
+++ b/meetings/2025-08-08.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-08-15.html
+++ b/meetings/2025-08-15.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-08-22.html
+++ b/meetings/2025-08-22.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-08-29.html
+++ b/meetings/2025-08-29.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-09-05.html
+++ b/meetings/2025-09-05.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-09-12.html
+++ b/meetings/2025-09-12.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-09-19.html
+++ b/meetings/2025-09-19.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-09-26.html
+++ b/meetings/2025-09-26.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-10-03.html
+++ b/meetings/2025-10-03.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-10-10.html
+++ b/meetings/2025-10-10.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-10-17.html
+++ b/meetings/2025-10-17.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-10-24.html
+++ b/meetings/2025-10-24.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-10-31.html
+++ b/meetings/2025-10-31.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-11-07.html
+++ b/meetings/2025-11-07.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-11-14.html
+++ b/meetings/2025-11-14.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-11-21.html
+++ b/meetings/2025-11-21.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-11-28.html
+++ b/meetings/2025-11-28.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-12-05.html
+++ b/meetings/2025-12-05.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-12-12.html
+++ b/meetings/2025-12-12.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-12-19.html
+++ b/meetings/2025-12-19.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2025-12-26.html
+++ b/meetings/2025-12-26.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-01-02.html
+++ b/meetings/2026-01-02.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-01-09.html
+++ b/meetings/2026-01-09.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-01-16.html
+++ b/meetings/2026-01-16.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-01-23.html
+++ b/meetings/2026-01-23.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-01-30.html
+++ b/meetings/2026-01-30.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-02-06.html
+++ b/meetings/2026-02-06.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-02-13.html
+++ b/meetings/2026-02-13.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-02-20.html
+++ b/meetings/2026-02-20.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-02-27.html
+++ b/meetings/2026-02-27.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-03-06.html
+++ b/meetings/2026-03-06.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-03-13.html
+++ b/meetings/2026-03-13.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-03-20.html
+++ b/meetings/2026-03-20.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-03-27.html
+++ b/meetings/2026-03-27.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-04-03.html
+++ b/meetings/2026-04-03.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-04-10.html
+++ b/meetings/2026-04-10.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/meetings/2026-04-17.html
+++ b/meetings/2026-04-17.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/news.html
+++ b/news.html
@@ -42,10 +42,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <!-- Structured Data - Breadcrumb -->
     <script type="application/ld+json">

--- a/portfolio/aws-org-scps.html
+++ b/portfolio/aws-org-scps.html
@@ -32,10 +32,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/portfolio/cloudgoat.html
+++ b/portfolio/cloudgoat.html
@@ -32,10 +32,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/portfolio/cnapp-comparison.html
+++ b/portfolio/cnapp-comparison.html
@@ -32,10 +32,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/portfolio/detection-lab.html
+++ b/portfolio/detection-lab.html
@@ -32,10 +32,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/portfolio/open-source-contribution.html
+++ b/portfolio/open-source-contribution.html
@@ -32,10 +32,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/portfolio/prowler-audit.html
+++ b/portfolio/prowler-audit.html
@@ -32,10 +32,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/portfolio/recreate-capital-one.html
+++ b/portfolio/recreate-capital-one.html
@@ -32,10 +32,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/presentations.html
+++ b/presentations.html
@@ -41,10 +41,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <!-- Structured Data -->
     <script type="application/ld+json">

--- a/privacy.html
+++ b/privacy.html
@@ -35,10 +35,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
   <noscript><style>.js-enabled header nav{display:block !important}</style></noscript>
 </head>
 

--- a/resources.html
+++ b/resources.html
@@ -41,11 +41,11 @@
     <link rel="dns-prefetch" href="https://github.com">
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <!-- Structured Data for SEO -->
     <script type="application/ld+json">

--- a/rss.html
+++ b/rss.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/security-policy.html
+++ b/security-policy.html
@@ -40,11 +40,11 @@
     <link rel="dns-prefetch" href="https://github.com">
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
   <noscript><style>.js-enabled header nav{display:block !important}</style></noscript>
 </head>
 

--- a/sessions.html
+++ b/sessions.html
@@ -40,10 +40,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <!-- Structured Data -->
     <script type="application/ld+json">

--- a/shared-responsibility-model.html
+++ b/shared-responsibility-model.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {

--- a/style.css
+++ b/style.css
@@ -1821,6 +1821,19 @@ footer {
     border-radius: 8px;
 }
 
+.hero-logo {
+    display: block;
+    width: auto;
+    height: 110px;
+    max-width: 90%;
+    margin: 0 auto 1.5rem;
+    padding: 14px 28px;
+    background: #f5f5f5;
+    border-radius: 14px;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+    box-sizing: content-box;
+}
+
 .memorial-link {
     color: #1d4ed8;
     text-decoration: underline;

--- a/threat-research.html
+++ b/threat-research.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <!-- Structured Data -->
     <script type="application/ld+json">

--- a/what-is-cloud-security.html
+++ b/what-is-cloud-security.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=00c7245c" as="style"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
-    <link rel="stylesheet" href="/style.css?v=00c7245c"
-        integrity="sha384-4AZB/PKAjmUqHAs33a955BQrnJFlyzT/H2P183T9zYzwES5tNyeGjLAvZEEZrvFc">
+    <link rel="preload" href="/style.css?v=ab65700f" as="style"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
+    <link rel="stylesheet" href="/style.css?v=ab65700f"
+        integrity="sha384-FoCFm5cXjBduxCr9YlnCgh4k6axjK3/8Nd8hX3MW5mFS0GxWcCWaG/nrgf+atRPY">
 
     <script type="application/ld+json">
     {


### PR DESCRIPTION
## What Changed

Adds the classic Google Cloud Platform hexagon + wordmark lockup as an inline SVG at the top of the [cloud-deployment.html](https://github.com/CloudSecurityOfficeHours/csoh.org/blob/main/cloud-deployment.html) hero so the page leads with a clear visual cue about the platform it documents. The logo sits on a light pill background that contrasts cleanly against the hero gradient.

## Type of Change

- [x] Feature / enhancement

## Testing

- [x] Previewed changes locally (verified hero renders with logo, computed styles correct, no console errors)
- [ ] Checked light mode and dark mode
- [ ] Checked mobile layout (DevTools responsive mode)
- [x] Verified links work (no link changes)
- [ ] Ran `python3 tools/check_all_site_urls.py` (not adding URLs)

## Notes

- New `.hero-logo` rule added in `style.css` (light pill, 110px tall, rounded corners, drop shadow).
- `update_sri.py` was re-run after the `style.css` edit, which refreshes the SRI integrity hashes and `?v=` cache-busters across all 146 pages that link `style.css` — that accounts for the bulk of the diff. No semantic HTML changes outside `cloud-deployment.html`.
- The wordmark falls back to a generic serif (Georgia) for "Google" and sans-serif (Helvetica/Arial) for "Cloud Platform" — Google's proprietary Catull/Product Sans aren't redistributable, so the typeface is approximate but the lockup reads correctly as the GCP logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)