### PR TITLE
Add GRC topic page; rename Threat Research dropdown to Detection and Response

### DIFF
--- a/403.html
+++ b/403.html
@@ -58,11 +58,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/404.html
+++ b/404.html
@@ -59,11 +59,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/about-shawn-nunley.html
+++ b/about-shawn-nunley.html
@@ -161,11 +161,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/ai-learning.html
+++ b/ai-learning.html
@@ -250,11 +250,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/breach-timeline.html
+++ b/breach-timeline.html
@@ -196,11 +196,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>

--- a/breaches/capital-one.html
+++ b/breaches/capital-one.html
@@ -135,11 +135,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>

--- a/breaches/lastpass.html
+++ b/breaches/lastpass.html
@@ -135,11 +135,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>

--- a/breaches/microsoft-sas-leak.html
+++ b/breaches/microsoft-sas-leak.html
@@ -135,11 +135,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>

--- a/breaches/mitnick-novell.html
+++ b/breaches/mitnick-novell.html
@@ -135,11 +135,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>

--- a/breaches/promptware.html
+++ b/breaches/promptware.html
@@ -135,11 +135,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>

--- a/breaches/scattered-spider-mgm.html
+++ b/breaches/scattered-spider-mgm.html
@@ -135,11 +135,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>

--- a/breaches/snowflake-unc5537.html
+++ b/breaches/snowflake-unc5537.html
@@ -135,11 +135,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>

--- a/breaches/solarwinds.html
+++ b/breaches/solarwinds.html
@@ -135,11 +135,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>

--- a/breaches/storm-0558.html
+++ b/breaches/storm-0558.html
@@ -135,11 +135,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>

--- a/breaches/uber.html
+++ b/breaches/uber.html
@@ -135,11 +135,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>

--- a/chat-resources.html
+++ b/chat-resources.html
@@ -58,11 +58,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/ci-cd.html
+++ b/ci-cd.html
@@ -170,11 +170,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html" aria-current="page">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/cloud-deployment.html
+++ b/cloud-deployment.html
@@ -119,11 +119,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/cloud-security-best-practices.html
+++ b/cloud-security-best-practices.html
@@ -135,11 +135,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/cloud-security-careers.html
+++ b/cloud-security-careers.html
@@ -172,11 +172,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/cloud-security-certifications.html
+++ b/cloud-security-certifications.html
@@ -316,11 +316,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/cloud-security-degree-programs.html
+++ b/cloud-security-degree-programs.html
@@ -180,11 +180,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/cloud-security-home-lab.html
+++ b/cloud-security-home-lab.html
@@ -165,11 +165,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/cloud-security-portfolio-projects.html
+++ b/cloud-security-portfolio-projects.html
@@ -119,11 +119,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/cloud-security-reading-list.html
+++ b/cloud-security-reading-list.html
@@ -132,11 +132,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html" aria-current="page">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/cloud-soc.html
+++ b/cloud-soc.html
@@ -160,11 +160,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -84,11 +84,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/community.html
+++ b/community.html
@@ -120,11 +120,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/conferences.html
+++ b/conferences.html
@@ -299,11 +299,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/containers.html
+++ b/containers.html
@@ -160,11 +160,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/contribute-resources.html
+++ b/contribute-resources.html
@@ -110,11 +110,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/contribute.html
+++ b/contribute.html
@@ -111,11 +111,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/cspm-vs-cnapp.html
+++ b/cspm-vs-cnapp.html
@@ -167,11 +167,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/ctfs.html
+++ b/ctfs.html
@@ -384,11 +384,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/faq.html
+++ b/faq.html
@@ -143,11 +143,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/github-actions.html
+++ b/github-actions.html
@@ -135,11 +135,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/glossary.html
+++ b/glossary.html
@@ -96,11 +96,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/grc.html
+++ b/grc.html
@@ -1,0 +1,831 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
+    <meta name="description"
+        content="Governance, Risk, and Compliance (GRC) for cloud — the three pillars defined, what cloud changes about GRC, the framework landscape (SOC 2, ISO 27001, PCI DSS, HIPAA, FedRAMP, NIST CSF, CIS Benchmarks, GDPR), policy-as-code, continuous compliance with CSPM/CNAPP, automated audit evidence, and the AWS / Azure / GCP native tools. Vendor-neutral.">
+    <meta name="keywords"
+        content="GRC, cloud GRC, governance risk compliance, SOC 2, ISO 27001, PCI DSS, HIPAA, FedRAMP, NIST CSF, CIS Benchmarks, GDPR, policy as code, compliance as code, CSPM, continuous compliance, audit evidence, AWS Audit Manager, Azure Policy, GCP Assured Workloads, OPA, Conftest">
+    <title>GRC for Cloud (Governance, Risk &amp; Compliance) - CSOH</title>
+
+    <link rel="canonical" href="https://csoh.org/grc.html">
+    <link rel="alternate" type="application/rss+xml" title="CSOH Cloud Security News" href="/feed.xml">
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <link rel="manifest" href="/manifest.json">
+    <link rel="author" type="text/plain" href="/humans.txt">
+    <meta name="theme-color" content="#2c3e50">
+
+    <meta property="og:title" content="GRC for Cloud (Governance, Risk &amp; Compliance) - CSOH">
+    <meta property="og:description"
+        content="A practitioner's guide to GRC in cloud — the three pillars, the framework landscape, policy-as-code, continuous compliance, audit evidence, and how AWS, Azure, and GCP each support the discipline.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://csoh.org/grc.html">
+    <meta property="og:image" content="https://csoh.org/banner.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="GRC for Cloud (Governance, Risk &amp; Compliance)">
+    <meta name="twitter:description"
+        content="Vendor-neutral guide to cloud GRC — frameworks, policy-as-code, continuous compliance, audit evidence, and the native tools.">
+    <meta name="twitter:image" content="https://csoh.org/banner.png">
+
+    <link rel="preconnect" href="https://csoh.kit.com" crossorigin>
+    <link rel="preconnect" href="https://github.com" crossorigin>
+    <link rel="dns-prefetch" href="https://github.com">
+
+    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
+        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
+        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "GRC for Cloud (Governance, Risk & Compliance)",
+      "description": "A vendor-neutral practitioner's guide to GRC in cloud — the three pillars, framework landscape, policy-as-code, continuous compliance, audit evidence, and how AWS, Azure, and GCP each support the discipline.",
+      "author": {
+        "@type": "Person",
+        "@id": "https://csoh.org/about-shawn-nunley.html#shawn-nunley",
+        "name": "Shawn Nunley",
+        "url": "https://csoh.org/about-shawn-nunley.html"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "Cloud Security Office Hours",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://csoh.org/banner.png"
+        }
+      },
+      "datePublished": "2026-05-16",
+      "dateModified": "2026-05-16",
+      "mainEntityOfPage": "https://csoh.org/grc.html",
+      "image": "https://csoh.org/banner.png"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://csoh.org/"},
+        {"@type": "ListItem", "position": 2, "name": "GRC", "item": "https://csoh.org/grc.html"}
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What is GRC in cloud security?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "GRC stands for Governance, Risk, and Compliance. Governance is the set of policies, roles, and decision-making structures that define how the organization operates in the cloud. Risk is the discipline of identifying, assessing, treating, and monitoring threats to those operations. Compliance is demonstrating — to auditors, regulators, and customers — that the controls you say you run actually run. In cloud, the three are tightly coupled because every control is an API call away from being changed, and every misconfiguration is auditable from a log."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Is SOC 2 mandatory for SaaS companies?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "It's not legally mandatory, but it's market-mandatory for most B2B SaaS. Enterprise procurement teams will ask for a SOC 2 Type II report during vendor review; without one, deals stall or close-lost. The practical path is: Type I (point-in-time) within 6 months of being ready, Type II (period-of-time, usually 6–12 months) within the first year. The Trust Services Criteria — Security is required, plus optional Availability, Confidentiality, Processing Integrity, and Privacy — define what the auditor evaluates."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How does compliance-as-code work?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Compliance-as-code expresses control requirements as machine-readable rules that run continuously against your cloud environment, instead of as PDFs that get manually audited once a year. The mechanics: write rules (Rego in OPA, AWS Config rules, Azure Policy definitions, GCP Organization Policy, or a CSPM/CNAPP's policy language); evaluate them on every resource change and on a schedule; emit findings to a dashboard, ticket queue, or SIEM; auto-remediate the high-confidence ones. The auditor gets an evidence trail of rule definitions, evaluation logs, and exception approvals instead of a quarterly screenshot."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Do I need a GRC platform tool, or is a spreadsheet enough?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Spreadsheets work for one framework and a handful of controls. Once you're maintaining mappings between SOC 2, ISO 27001, and PCI DSS — all of which overlap by 60–80% — and tracking evidence freshness across a hundred controls, a platform pays for itself. Vanta, Drata, Secureframe, OneTrust, Hyperproof, ServiceNow GRC, and similar tools all collapse the work to one source of truth with automated evidence collection from the cloud APIs. Pick on integration depth with your cloud, not on the marketing site."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What is the difference between a CSPM and a GRC platform?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "A CSPM (Cloud Security Posture Management) tool watches your cloud environment for misconfigurations and policy drift in near-real time — security-shaped findings. A GRC platform tracks controls, frameworks, evidence, exceptions, risks, and audit readiness across the whole organization — audit-shaped findings. They overlap on the 'is this control passing?' question. Mature programs run both: the CSPM/CNAPP as the live sensor that produces evidence, the GRC platform as the system of record that organizes evidence against frameworks and presents it to auditors."
+          }
+        }
+      ]
+    }
+    </script>
+  <noscript><style>.js-enabled header nav{display:block !important}</style></noscript>
+</head>
+
+<body class="js-enabled">
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+
+    <header>
+        <div class="header-content">
+            <a href="index.html" class="logo-link">
+                <div class="logo">
+                    <div class="logo-title">CSOH</div>
+                    <p>Cloud Security Office Hours</p>
+                </div>
+            </a>
+            <button class="hamburger" aria-label="Toggle navigation" aria-expanded="false">☰</button>
+            <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
+            <nav>
+                <ul>
+                    <li><a href="index.html">Home</a></li>
+                    <li><a href="news.html">News</a></li>
+                    <li class="has-dropdown">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                        <li><a href="learning-path.html">Learning Path</a></li>
+                        <li><a href="ai-learning.html">AI Learning</a></li>
+                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                        <li><a href="cloud-security-careers.html">Careers</a></li>
+                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                        <li><a href="resources.html">Resources</a></li>
+                      </ul>
+                    </li>
+                    <li class="has-dropdown">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                        <li><a href="landing-zones.html">Landing Zones</a></li>
+                        <li><a href="containers.html">Containers</a></li>
+                        <li><a href="kubernetes.html">Kubernetes</a></li>
+                        <li><a href="serverless.html">Serverless</a></li>
+                        <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html" aria-current="page">GRC</a></li>
+                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                      </ul>
+                    </li>
+                    <li class="has-dropdown">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="threat-research.html">Threat Research</a></li>
+                        <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
+                        <li><a href="cloud-soc.html">Cloud SOC</a></li>
+                        <li><a href="ctfs.html">CTFs</a></li>
+                      </ul>
+                    </li>
+                    <li class="has-dropdown">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="sessions.html">Zoom Sessions</a></li>
+                        <li><a href="community.html">Community &amp; Signal</a></li>
+                        <li><a href="conferences.html">Conferences</a></li>
+                        <li><a href="meetings.html">Meeting Recaps</a></li>
+                        <li><a href="presentations.html">Presentations</a></li>
+                        <li><a href="chat-resources.html">Chat Resources</a></li>
+                      </ul>
+                    </li>
+                    <li class="has-dropdown">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="contribute.html">Contribute Overview</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
+                      </ul>
+                    </li>
+                    <li class="has-dropdown">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="glossary.html">Glossary</a></li>
+                        <li><a href="faq.html">FAQ</a></li>
+                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
+                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                      </ul>
+                    </li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <nav class="breadcrumb-nav" aria-label="Breadcrumb">
+        <ol>
+            <li><a href="index.html">Home</a></li>
+            <li><span aria-current="page">GRC</span></li>
+        </ol>
+    </nav>
+
+    <section class="hero hero--illustrated">
+      <div class="hero-inner">
+        <div class="hero-text">
+          <h1>GRC for Cloud</h1>
+          <p>Governance, Risk, and Compliance — the discipline that makes cloud security legible to auditors, regulators, executives, and the customers who buy from you. Vendor-neutral guide to the three pillars, the framework landscape, policy-as-code, continuous compliance, audit evidence in cloud, and the tools each cloud ships natively to support the work.</p>
+          <div class="cta-buttons">
+            <a href="#frameworks" class="btn btn-primary">Framework landscape →</a>
+            <a href="#comparison" class="btn btn-secondary">AWS / Azure / GCP comparison</a>
+          </div>
+        </div>
+        <div class="hero-illustration" aria-hidden="true">
+          <svg viewBox="0 0 600 480" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Illustration of three pillars labeled Governance, Risk, and Compliance supporting a cloud, with framework badges floating around">
+            <defs>
+              <linearGradient id="grc-cloud" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#bae6fd"/><stop offset="60%" stop-color="#38bdf8"/><stop offset="100%" stop-color="#2563eb"/></linearGradient>
+              <linearGradient id="grc-pillar-g" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#7e22ce"/><stop offset="100%" stop-color="#4c1d95"/></linearGradient>
+              <linearGradient id="grc-pillar-r" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#dc2626"/><stop offset="100%" stop-color="#7f1d1d"/></linearGradient>
+              <linearGradient id="grc-pillar-c" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#0d9488"/><stop offset="100%" stop-color="#134e4a"/></linearGradient>
+              <radialGradient id="grc-halo" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#7dd3fc" stop-opacity="0.35"/><stop offset="100%" stop-color="#7dd3fc" stop-opacity="0"/></radialGradient>
+            </defs>
+            <circle cx="300" cy="240" r="200" fill="url(#grc-halo)"/>
+            <!-- Cloud at top -->
+            <path d="M 200,80 a 50,50 0 0,1 60,-30 a 70,70 0 0,1 130,0 a 50,50 0 0,1 50,30 a 45,45 0 0,1 -25,80 H 220 a 45,45 0 0,1 -20,-80 z" fill="url(#grc-cloud)" stroke="#fff" stroke-width="1.5" stroke-opacity="0.4"/>
+            <text x="300" y="105" text-anchor="middle" fill="#0c4a6e" font-size="14" font-weight="700">Cloud environment</text>
+            <text x="300" y="125" text-anchor="middle" fill="#0c4a6e" font-size="11">controls · evidence · audits</text>
+            <!-- Capital plates above pillars -->
+            <rect x="80" y="180" width="440" height="14" rx="2" fill="#1f2937" stroke="#fbbf24" stroke-width="1"/>
+            <!-- Three pillars -->
+            <g>
+              <rect x="100" y="200" width="100" height="200" fill="url(#grc-pillar-g)" stroke="#a78bfa" stroke-width="2"/>
+              <text x="150" y="305" text-anchor="middle" fill="#fff" font-size="22" font-weight="800">G</text>
+              <text x="150" y="330" text-anchor="middle" fill="#e0e7ff" font-size="11" font-weight="600">Governance</text>
+              <text x="150" y="348" text-anchor="middle" fill="#c7d2fe" font-size="9">policies · roles</text>
+
+              <rect x="250" y="200" width="100" height="200" fill="url(#grc-pillar-r)" stroke="#fb7185" stroke-width="2"/>
+              <text x="300" y="305" text-anchor="middle" fill="#fff" font-size="22" font-weight="800">R</text>
+              <text x="300" y="330" text-anchor="middle" fill="#fecaca" font-size="11" font-weight="600">Risk</text>
+              <text x="300" y="348" text-anchor="middle" fill="#fecaca" font-size="9">identify · treat</text>
+
+              <rect x="400" y="200" width="100" height="200" fill="url(#grc-pillar-c)" stroke="#5eead4" stroke-width="2"/>
+              <text x="450" y="305" text-anchor="middle" fill="#fff" font-size="22" font-weight="800">C</text>
+              <text x="450" y="330" text-anchor="middle" fill="#a7f3d0" font-size="11" font-weight="600">Compliance</text>
+              <text x="450" y="348" text-anchor="middle" fill="#a7f3d0" font-size="9">evidence · attest</text>
+            </g>
+            <!-- Base plate -->
+            <rect x="70" y="404" width="460" height="16" rx="2" fill="#1f2937" stroke="#fbbf24" stroke-width="1"/>
+            <!-- Framework badges -->
+            <g>
+              <rect x="20" y="195" width="60" height="20" rx="10" fill="#0d1424" stroke="#fbbf24" stroke-width="1"/>
+              <text x="50" y="209" text-anchor="middle" fill="#fbbf24" font-size="10" font-weight="700">SOC 2</text>
+              <rect x="20" y="225" width="60" height="20" rx="10" fill="#0d1424" stroke="#60a5fa" stroke-width="1"/>
+              <text x="50" y="239" text-anchor="middle" fill="#60a5fa" font-size="10" font-weight="700">ISO 27001</text>
+              <rect x="20" y="255" width="60" height="20" rx="10" fill="#0d1424" stroke="#f97316" stroke-width="1"/>
+              <text x="50" y="269" text-anchor="middle" fill="#f97316" font-size="10" font-weight="700">PCI DSS</text>
+              <rect x="20" y="285" width="60" height="20" rx="10" fill="#0d1424" stroke="#84cc16" stroke-width="1"/>
+              <text x="50" y="299" text-anchor="middle" fill="#84cc16" font-size="10" font-weight="700">HIPAA</text>
+
+              <rect x="520" y="195" width="60" height="20" rx="10" fill="#0d1424" stroke="#a78bfa" stroke-width="1"/>
+              <text x="550" y="209" text-anchor="middle" fill="#a78bfa" font-size="10" font-weight="700">FedRAMP</text>
+              <rect x="520" y="225" width="60" height="20" rx="10" fill="#0d1424" stroke="#22d3ee" stroke-width="1"/>
+              <text x="550" y="239" text-anchor="middle" fill="#22d3ee" font-size="10" font-weight="700">NIST CSF</text>
+              <rect x="520" y="255" width="60" height="20" rx="10" fill="#0d1424" stroke="#34d399" stroke-width="1"/>
+              <text x="550" y="269" text-anchor="middle" fill="#34d399" font-size="10" font-weight="700">CIS</text>
+              <rect x="520" y="285" width="60" height="20" rx="10" fill="#0d1424" stroke="#f472b6" stroke-width="1"/>
+              <text x="550" y="299" text-anchor="middle" fill="#f472b6" font-size="10" font-weight="700">GDPR</text>
+            </g>
+            <!-- Arrows from badges to pillars -->
+            <g stroke="#a78bfa" stroke-width="1" stroke-dasharray="3 4" fill="none" opacity="0.45">
+              <line x1="80" y1="205" x2="100" y2="230"/>
+              <line x1="80" y1="235" x2="100" y2="260"/>
+              <line x1="80" y1="265" x2="100" y2="290"/>
+              <line x1="80" y1="295" x2="100" y2="320"/>
+              <line x1="520" y1="205" x2="500" y2="230"/>
+              <line x1="520" y1="235" x2="500" y2="260"/>
+              <line x1="520" y1="265" x2="500" y2="290"/>
+              <line x1="520" y1="295" x2="500" y2="320"/>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </section>
+
+    <main class="container contribute-article" id="main-content">
+
+        <figure class="page-photo">
+          <picture>
+            <source srcset="/img/photos/contract-signing.webp" type="image/webp">
+            <img src="/img/photos/contract-signing.jpg" alt="Detailed view of a hand writing a signature on an official document with a ballpoint pen" width="1880" height="1253" loading="lazy" decoding="async">
+          </picture>
+          <figcaption>Photo by Tima Miroshnichenko on Pexels</figcaption>
+        </figure>
+
+        <p class="page-meta"><time datetime="2026-05-16">Last updated <strong>2026-05-16</strong></time> · <a href="about-shawn-nunley.html" rel="author">By Shawn Nunley</a> · Vendor-neutral · <a href="https://github.com/CloudSecurityOfficeHours/csoh.org/blob/main/grc.html" target="_blank" rel="noopener noreferrer">View source on GitHub</a></p>
+
+        <div class="info-box--blue">
+            <p><strong>The 30-second version:</strong> <strong>GRC</strong> (Governance, Risk, and Compliance) is the discipline that turns abstract security intent into documented controls, evidence, and audit-ready posture. <strong>Governance</strong> = who decides, what's the policy, who's accountable. <strong>Risk</strong> = what could go wrong, how likely, how bad, what are we doing about it. <strong>Compliance</strong> = can you prove, to an auditor or regulator, that the controls you claim actually run.</p>
+            <p style="margin-top:0.75rem;">Cloud changes GRC in two practical ways: every control is an <em>API call</em> away from drifting (so it has to be continuously monitored, not annually sampled), and most controls leave a log behind (so evidence collection is automatable). The modern stack is <strong>compliance-as-code</strong> for the rules, <strong>CSPM/CNAPP</strong> for live sensing, a <strong>GRC platform</strong> for the system-of-record, and a small <strong>GRC team</strong> that owns the mapping, exceptions, and auditor relationships.</p>
+        </div>
+
+        <div class="toc">
+            <h2>📖 On this page</h2>
+            <ol>
+                <li><a href="#what-is">What GRC is</a></li>
+                <li><a href="#three-pillars">The three pillars</a></li>
+                <li><a href="#cloud-changes">What cloud changes about GRC</a></li>
+                <li><a href="#frameworks">The framework landscape</a></li>
+                <li><a href="#control-frameworks">Control frameworks &amp; baselines</a></li>
+                <li><a href="#policy-as-code">Policy-as-code &amp; compliance-as-code</a></li>
+                <li><a href="#continuous">Continuous compliance with CSPM/CNAPP</a></li>
+                <li><a href="#evidence">Audit evidence in cloud</a></li>
+                <li><a href="#platforms">GRC platforms</a></li>
+                <li><a href="#comparison">AWS, Azure, and GCP side-by-side</a></li>
+                <li><a href="#roles">Roles &amp; responsibilities</a></li>
+                <li><a href="#maturity">Maturity stages</a></li>
+                <li><a href="#pitfalls">Common pitfalls</a></li>
+                <li><a href="#further">Further reading</a></li>
+                <li><a href="#faq">FAQ</a></li>
+            </ol>
+        </div>
+
+        <section id="what-is">
+            <h2>What GRC is</h2>
+            <p>GRC is the discipline that translates security <em>intent</em> ("we will protect customer data") into <em>controls</em> (specific things we do — encrypt at rest, MFA on admin accounts, rotate keys), into <em>evidence</em> (proof those controls run), and into <em>attestation</em> (a third party signing off that what we say is true). Done well, it's the connective tissue between the security org, the rest of the business, and the outside world of auditors, regulators, and customers who want assurance before they buy.</p>
+            <p>Done badly, it's the worst caricature security has: a separate team, a separate vocabulary, screenshots-for-screenshots'-sake, and a calendar driven by audit windows rather than by what's actually changing in the environment. The good news is that the cloud-native version of GRC can avoid most of those failure modes if the team builds with the right primitives from the start.</p>
+            <p>This page is the practitioner's view — what the work actually is in 2026, which frameworks you'll encounter, how compliance-as-code changes the game, and how to choose between native cloud tools, CSPM/CNAPP, and dedicated GRC platforms.</p>
+        </section>
+
+        <section id="three-pillars">
+            <h2>The three pillars</h2>
+            <p>The "G", "R", and "C" are distinct disciplines that interlock. Most orgs do one well, one passably, and one badly — recognizing which is yours is the first step in maturing the program.</p>
+            <div class="pillar-grid">
+                <div class="pillar-card pillar-card-iam">
+                    <h3>Governance</h3>
+                    <p>Policies, standards, decision-making rights, and accountability. Who can approve a production deployment? Who owns the IAM model? Which exceptions can which manager sign? Governance answers the org-chart questions of security. Outputs: an information-security policy, role definitions, an exception-approval workflow, and a documented owner for every control.</p>
+                </div>
+                <div class="pillar-card pillar-card-detect">
+                    <h3>Risk</h3>
+                    <p>Identifying threats, assessing likelihood and impact, deciding what to do (accept, avoid, mitigate, transfer), and monitoring whether the treatments are working. Outputs: a risk register, residual-risk scoring, treatment plans linked to controls, and a periodic review cadence that survives team turnover.</p>
+                </div>
+                <div class="pillar-card pillar-card-compliance">
+                    <h3>Compliance</h3>
+                    <p>Demonstrating that controls run as policy requires, mapped to one or more external frameworks, with evidence an auditor will accept. Outputs: framework mappings, evidence collected on a defined cadence, gap analyses, and clean audit reports (SOC 2, ISO 27001, PCI DSS, etc.) that procurement teams can read.</p>
+                </div>
+            </div>
+            <p>The pillars are reinforcing. A weak governance pillar produces inconsistent risk decisions; a weak risk pillar produces compliance work that costs more than it should because nothing is risk-prioritized; a weak compliance pillar produces well-governed, well-risked programs that customers can't buy from because there's no report to send them.</p>
+        </section>
+
+        <section id="cloud-changes">
+            <h2>What cloud changes about GRC</h2>
+            <p>The fundamentals of GRC predate cloud by decades. The execution looks meaningfully different once your workloads run in someone else's data center, behind APIs that auditors don't have ssh access to.</p>
+            <div class="comparison-table">
+                <table>
+                    <thead>
+                        <tr>
+                            <th scope="col" class="ct-row-head">Dimension</th>
+                            <th scope="col">Traditional GRC</th>
+                            <th scope="col">Cloud GRC</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th scope="row">Control unit</th>
+                            <td>A server, a network segment, a policy doc</td>
+                            <td>An API call, a resource configuration, an identity</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Evidence shape</th>
+                            <td>Screenshots, manual log exports, attestation letters</td>
+                            <td>API queries, structured JSON, log streams, signed config snapshots</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Audit cadence</th>
+                            <td>Annual or quarterly point-in-time samples</td>
+                            <td>Continuous — every config change generates an event</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Shared responsibility</th>
+                            <td>You own the stack end-to-end</td>
+                            <td><a href="shared-responsibility-model.html">Provider owns part</a>; your scope shrinks but doesn't disappear</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Change rate</th>
+                            <td>Quarterly releases, change-advisory boards</td>
+                            <td>Hundreds of deploys / day; controls must keep up</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Auditor knowledge</th>
+                            <td>Familiar with on-prem controls</td>
+                            <td>Variable — newer firms specialize, older ones still learning the cloud model</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Failure mode</th>
+                            <td>Audit window finds the gap; remediate before next audit</td>
+                            <td>Misconfiguration is exploitable in hours; the auditor finding lags the breach</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <p>The bottom row matters most. In traditional GRC, the audit finding generally arrives <em>before</em> the breach. In cloud, an attacker scanning for public S3 buckets, exposed IMDS, or overly permissive trust policies can act in minutes — your control either holds at the moment of misconfiguration, or it doesn't hold at all. GRC has to keep up with the cloud's change rate, not the auditor's calendar.</p>
+        </section>
+
+        <section id="frameworks">
+            <h2>The framework landscape</h2>
+            <p>You will eventually be asked about most of these. The pragmatic strategy is to pick one as your <em>primary</em> internal framework, map all others to it, and run a single control set with framework-specific overlays where required.</p>
+            <h3><a href="https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2" target="_blank" rel="noopener noreferrer">SOC 2</a></h3>
+            <p>The de facto B2B SaaS attestation in North America. AICPA-defined Trust Services Criteria — Security is required; Availability, Confidentiality, Processing Integrity, and Privacy are optional add-ons. Type I is a point-in-time design assessment; Type II covers a period (typically 6 or 12 months) and verifies the controls actually ran. Most enterprise procurement teams require Type II.</p>
+            <h3><a href="https://www.iso.org/standard/27001" target="_blank" rel="noopener noreferrer">ISO 27001</a></h3>
+            <p>The international information-security management system (ISMS) standard. More prescriptive than SOC 2 on management-system structure, less prescriptive on individual technical controls. Required or preferred outside North America for most enterprise buyers; increasingly co-required with SOC 2. Annex A (in the 2022 revision) lists 93 reference controls.</p>
+            <h3><a href="https://www.pcisecuritystandards.org/" target="_blank" rel="noopener noreferrer">PCI DSS</a></h3>
+            <p>The Payment Card Industry Data Security Standard. Required if you store, process, or transmit cardholder data. v4.0 (in force) places much heavier expectations on continuous monitoring and risk-based scoping than v3.2.1 did. Tokenization and scope reduction are the highest-leverage moves; doing it the brute-force way (everything in scope) is several multiples more expensive.</p>
+            <h3><a href="https://www.hhs.gov/hipaa/for-professionals/index.html" target="_blank" rel="noopener noreferrer">HIPAA / HITECH</a></h3>
+            <p>U.S. healthcare. The Security Rule defines administrative, physical, and technical safeguards for protected health information (PHI). All three major clouds offer BAA-eligible services; using a service not on your provider's BAA list with PHI is a quiet path to a finding. Breach Notification Rule sets the timeline for disclosure.</p>
+            <h3><a href="https://www.fedramp.gov/" target="_blank" rel="noopener noreferrer">FedRAMP</a></h3>
+            <p>U.S. federal cloud authorization. Three impact levels (Low, Moderate, High) drawn from <a href="https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final" target="_blank" rel="noopener noreferrer">NIST SP 800-53</a>. Moderate is the most common; High applies to data whose loss would have severe or catastrophic effect. The authorization process is long (12–18+ months typical) and expensive; most vendors use a 3PAO and target an agency sponsor or the Joint Authorization Board.</p>
+            <h3><a href="https://www.nist.gov/cyberframework" target="_blank" rel="noopener noreferrer">NIST Cybersecurity Framework (CSF)</a></h3>
+            <p>Not an attestation, but the most-cited common-language framework for security programs. CSF 2.0 organizes work into six functions: Govern, Identify, Protect, Detect, Respond, Recover. Useful as the meta-framework that maps SOC 2, ISO 27001, and PCI DSS to a shared vocabulary for executive reporting.</p>
+            <h3><a href="https://www.cisecurity.org/cis-benchmarks" target="_blank" rel="noopener noreferrer">CIS Benchmarks</a></h3>
+            <p>Technical baselines — specific configurations for AWS, Azure, GCP, Kubernetes, Docker, OS images, and more. Not attestations; they're the implementation-level baseline most CSPM tools score against by default. Aligning your environment with CIS produces evidence that crosswalks cleanly to SOC 2, ISO 27001, and PCI DSS controls.</p>
+            <h3>Privacy: <a href="https://gdpr.eu/" target="_blank" rel="noopener noreferrer">GDPR</a>, <a href="https://oag.ca.gov/privacy/ccpa" target="_blank" rel="noopener noreferrer">CCPA/CPRA</a>, and regional</h3>
+            <p>Personal-data protection laws. GDPR (EU), CCPA / CPRA (California), LGPD (Brazil), PIPL (China), and dozens more. Distinct from security frameworks but heavily overlapping — most security controls also serve privacy obligations. Data-residency, data-subject-rights workflows, and lawful-basis tracking are the new asks; cloud providers have residency tooling (regions, sovereign-cloud offerings) to support them.</p>
+            <h3>Sector-specific</h3>
+            <ul>
+                <li><strong>SOX</strong> — U.S. public-company financial-reporting controls. ITGC (IT general controls) is the security-relevant slice.</li>
+                <li><strong>NIST SP 800-171</strong> / <strong>CMMC</strong> — U.S. defense supply chain.</li>
+                <li><strong>NYDFS Part 500</strong>, <strong>FFIEC</strong>, <strong>GLBA Safeguards Rule</strong> — U.S. financial services.</li>
+                <li><strong>NERC CIP</strong> — North American electric utilities.</li>
+                <li><strong>NIS2</strong>, <strong>DORA</strong> — EU critical-infrastructure and financial-services resilience.</li>
+                <li><strong>IRAP</strong> (Australia), <strong>ENS</strong> (Spain), <strong>BSI C5</strong> (Germany), <strong>HKMA</strong> (Hong Kong) — country-specific cloud requirements.</li>
+            </ul>
+            <h3>The 80/20 of mapping</h3>
+            <p>SOC 2, ISO 27001, and most other frameworks overlap by 60–80%. Pick one as the internal source-of-truth control set; map every other framework to it. Add framework-specific controls only where the others don't already cover the requirement (e.g., PCI DSS network segmentation, HIPAA breach-notification timelines, FedRAMP continuous monitoring deliverables). This is the single highest-leverage decision in a multi-framework program.</p>
+        </section>
+
+        <section id="control-frameworks">
+            <h2>Control frameworks &amp; baselines</h2>
+            <p>Where attestation frameworks (SOC 2, ISO 27001) define <em>what</em> outcomes you must demonstrate, control frameworks define <em>how</em> at the configuration level. Cloud GRC programs reach for these:</p>
+            <ul>
+                <li><strong><a href="https://www.cisecurity.org/cis-benchmarks" target="_blank" rel="noopener noreferrer">CIS Benchmarks</a></strong> — per-platform technical baselines. CIS AWS Foundations, CIS Azure Foundations, CIS GCP Foundations, CIS Kubernetes, plus dozens of OS and application benchmarks. The lingua franca of CSPM rule libraries.</li>
+                <li><strong><a href="https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final" target="_blank" rel="noopener noreferrer">NIST SP 800-53</a></strong> — comprehensive U.S. federal control catalog. Underpins FedRAMP, used widely as a reference even outside government. Rev 5 is current.</li>
+                <li><strong><a href="https://cloudsecurityalliance.org/research/cloud-controls-matrix" target="_blank" rel="noopener noreferrer">CSA Cloud Controls Matrix (CCM)</a></strong> — cloud-specific control framework from the Cloud Security Alliance, with crosswalks to most major attestation frameworks. Used heavily for vendor-risk questionnaires (CAIQ).</li>
+                <li><strong><a href="https://aws.amazon.com/architecture/well-architected/" target="_blank" rel="noopener noreferrer">AWS Well-Architected Framework — Security Pillar</a></strong>, <strong><a href="https://learn.microsoft.com/en-us/security/zero-trust/azure-infrastructure-cloud-security-baseline" target="_blank" rel="noopener noreferrer">Azure Cloud Security Baseline</a></strong>, <strong><a href="https://cloud.google.com/architecture/framework/security" target="_blank" rel="noopener noreferrer">GCP Architecture Framework — Security</a></strong> — provider-authored baselines. Practical starting points; well-aligned with the CIS Benchmarks for the same platform.</li>
+                <li><strong><a href="https://attack.mitre.org/matrices/enterprise/cloud/" target="_blank" rel="noopener noreferrer">MITRE ATT&amp;CK Cloud</a></strong> — not a control framework, but the threat model your controls are defending against. Mapping detections (see <a href="cloud-soc.html">Cloud SOC</a>) and preventative controls to ATT&amp;CK techniques produces the coverage-gap analyses auditors and CISOs both find legible.</li>
+            </ul>
+        </section>
+
+        <section id="policy-as-code">
+            <h2>Policy-as-code &amp; compliance-as-code</h2>
+            <p>The biggest mechanical change cloud brings to GRC is that <em>policy can be code</em>. The control "S3 buckets must have public access blocked" can be a one-line rule that runs against every bucket every time anything changes, instead of a sentence in a PDF that gets sampled annually.</p>
+            <h3>The languages and runtimes</h3>
+            <ul>
+                <li><strong><a href="https://www.openpolicyagent.org/" target="_blank" rel="noopener noreferrer">Open Policy Agent (OPA)</a> / Rego</strong> — vendor-neutral, runs anywhere. The CNCF graduated standard. Used heavily for Kubernetes admission control (Gatekeeper / Kyverno), Terraform pre-apply checks (Conftest), and API authorization.</li>
+                <li><strong><a href="https://docs.aws.amazon.com/config/" target="_blank" rel="noopener noreferrer">AWS Config Rules</a></strong> — managed and custom rules that evaluate resource configurations continuously and on every change.</li>
+                <li><strong><a href="https://learn.microsoft.com/en-us/azure/governance/policy/" target="_blank" rel="noopener noreferrer">Azure Policy</a></strong> — JSON-defined rules that audit or enforce at the subscription / management-group scope. Pairs with Initiative definitions to bundle controls into framework-aligned sets.</li>
+                <li><strong><a href="https://cloud.google.com/policy-intelligence/docs/organization-policy-overview" target="_blank" rel="noopener noreferrer">GCP Organization Policy</a></strong> — constraint-based enforcement at organization, folder, or project scope. Pairs with <a href="https://cloud.google.com/security-command-center/docs/concepts-security-health-analytics-overview" target="_blank" rel="noopener noreferrer">Security Health Analytics</a> for detective rules.</li>
+                <li><strong><a href="https://developer.hashicorp.com/sentinel" target="_blank" rel="noopener noreferrer">Sentinel</a></strong> — HashiCorp's policy-as-code for Terraform Cloud / Enterprise.</li>
+                <li><strong><a href="https://kyverno.io/" target="_blank" rel="noopener noreferrer">Kyverno</a></strong>, <strong><a href="https://open-policy-agent.github.io/gatekeeper/" target="_blank" rel="noopener noreferrer">Gatekeeper</a></strong> — Kubernetes admission policy (see also the <a href="kubernetes.html">Kubernetes page</a>).</li>
+                <li><strong>CSPM policy languages</strong> — Wiz, Prisma Cloud, Lacework, Orca, Defender for Cloud, and every other CSPM ships its own rule library with crosswalks to CIS, NIST, SOC 2, ISO 27001, PCI DSS, HIPAA. Most also accept custom rules in the platform's own DSL.</li>
+            </ul>
+            <h3>Where to enforce</h3>
+            <ul>
+                <li><strong>Pre-deploy</strong> — the highest-leverage spot. <a href="ci-cd.html">CI/CD</a> pipelines run Conftest / Checkov / tfsec / OPA against Terraform plans, blocking the misconfiguration before it ships. Kubernetes admission controllers reject non-conformant resources before they reach the cluster.</li>
+                <li><strong>At deploy</strong> — cloud-native enforcement at the API. Service control policies, organization policies, deny-by-default IAM permissions stop the change at the cloud's edge even if pipeline checks were bypassed.</li>
+                <li><strong>Post-deploy</strong> — CSPM, Config Rules, Security Command Center, Defender for Cloud catch the drift. Auto-remediation handles the high-confidence findings; everything else flows to a ticket queue.</li>
+            </ul>
+            <p>The three layers are complementary. Pre-deploy is cheapest and fastest; post-deploy is the safety net for everything that slips. Skipping pre-deploy because "the CSPM catches it" means you ship the misconfiguration and rely on the post-deploy detection to be tuned, alerted, and acted on — at which point the bucket may already have been scanned.</p>
+        </section>
+
+        <section id="continuous">
+            <h2>Continuous compliance with CSPM/CNAPP</h2>
+            <p>A <a href="cspm-vs-cnapp.html">CSPM (Cloud Security Posture Management)</a> tool inventories your cloud, evaluates every resource against a rule set, and emits findings continuously. When the rule set is tagged with the framework it satisfies (CIS, NIST, SOC 2, ISO 27001, PCI DSS, HIPAA, etc.), the CSPM becomes the live sensor for your compliance posture — not the system of record, but the source of truth for "is this control passing <em>right now</em>?"</p>
+            <h3>What CSPM/CNAPP gives GRC</h3>
+            <ul>
+                <li><strong>Continuous evidence.</strong> Every control's pass / fail state, timestamped, queryable by framework.</li>
+                <li><strong>Drift detection.</strong> A control that was compliant yesterday and isn't today is now an alert, not a quarterly-audit discovery.</li>
+                <li><strong>Risk-prioritized remediation.</strong> A modern CNAPP weighs findings by exploitability and exposure (a public S3 bucket with sensitive data + an over-permissioned role + a CVE in a workload that touches it is graver than any one finding alone). GRC inherits this prioritization for free.</li>
+                <li><strong>Exception workflows.</strong> The platform records the approval, the expiration date, the compensating control, and the owner — the artifacts auditors actually want.</li>
+                <li><strong>Auditor-ready exports.</strong> Most CSPMs produce framework-mapped reports out of the box. The auditor sees the same evidence the security team sees, on the same cadence.</li>
+            </ul>
+            <h3>What CSPM/CNAPP doesn't give you</h3>
+            <ul>
+                <li><strong>The non-technical controls.</strong> Background checks, security training completion, vendor risk assessments, business-continuity plans — none of these are visible from a cloud API. A GRC platform (or a well-organized wiki) is still required.</li>
+                <li><strong>The framework structure.</strong> CSPM finds control failures; it doesn't write the policy that says "this control exists." The framework mapping, the policy document, the exception register — that's GRC-team work.</li>
+                <li><strong>The auditor relationship.</strong> Tools don't answer auditor questions. Humans do.</li>
+            </ul>
+            <p>The pragmatic split: CSPM/CNAPP for the technical controls (probably 60–70% of any modern framework), GRC platform or wiki for the rest, both feeding into the same audit-evidence repository.</p>
+        </section>
+
+        <section id="evidence">
+            <h2>Audit evidence in cloud</h2>
+            <p>The evidence shape changes in cloud, and so does the work of gathering it. The categories an auditor will ask about — and what cloud-native sources answer them:</p>
+            <div class="pillar-grid">
+                <div class="pillar-card pillar-card-iam">
+                    <h3>Identity &amp; access</h3>
+                    <p>Who has access to what, with what permissions, since when, used how recently. IAM Access Analyzer (AWS), Entra ID + Defender (Azure), IAM Recommender + Asset Inventory (GCP). Last-used and unused-access reports answer "least privilege?" directly.</p>
+                </div>
+                <div class="pillar-card pillar-card-posture">
+                    <h3>Configuration</h3>
+                    <p>Current state of every resource at any point in time. AWS Config history, Azure Resource Graph snapshots, GCP Asset Inventory history. Re-hydrates "what did this resource look like during the audit period?" without re-running scans.</p>
+                </div>
+                <div class="pillar-card pillar-card-network">
+                    <h3>Activity</h3>
+                    <p>Who did what, when, from where. CloudTrail (AWS), Activity Log (Azure), Cloud Audit Logs (GCP). The single most-requested evidence class in any cloud audit.</p>
+                </div>
+                <div class="pillar-card pillar-card-detect">
+                    <h3>Encryption &amp; keys</h3>
+                    <p>What's encrypted, with which keys, rotated when. KMS / Key Vault / Cloud KMS APIs; the keyring + key-usage audit logs that prove customer-managed-key claims.</p>
+                </div>
+                <div class="pillar-card pillar-card-data">
+                    <h3>Vulnerability &amp; patching</h3>
+                    <p>What CVEs exist on what workloads, age of unremediated findings, patch SLA compliance. CSPM/CNAPP, Inspector, Defender for Cloud, Security Command Center. Tied to your remediation-SLA policy in the GRC platform.</p>
+                </div>
+                <div class="pillar-card pillar-card-supply">
+                    <h3>Change management</h3>
+                    <p>Every production change ties back to a ticket, a reviewer, a CI build, an attested artifact. GitHub / GitLab audit log, deployment pipeline records, IaC plan history. (See <a href="ci-cd.html">CI/CD</a> and <a href="github-actions.html">our pipeline writeup</a>.)</p>
+                </div>
+                <div class="pillar-card pillar-card-stage1">
+                    <h3>Incident response</h3>
+                    <p>Tickets, runbooks executed, post-incident reviews, evidence of timely notification per regulatory obligation. SIEM incident records, IR ticketing system, communications archive.</p>
+                </div>
+                <div class="pillar-card pillar-card-compliance">
+                    <h3>Third-party / vendor</h3>
+                    <p>Subprocessor list, due-diligence records, contracted security obligations, data-processing addenda. Lives in the GRC platform; rarely cloud-native.</p>
+                </div>
+            </div>
+            <h3>Automating evidence collection</h3>
+            <p>The 2026 reality: the GRC platforms that have integrated with cloud APIs collect most of the technical evidence automatically. Vanta, Drata, Secureframe, Hyperproof, ServiceNow GRC, OneTrust, and others connect to AWS, Azure, GCP, GitHub, identity providers, MDM, HRIS, ticketing — and refresh evidence on a schedule. The control-engineering work is in <em>defining</em> the mapping; once defined, the evidence is mostly free.</p>
+        </section>
+
+        <figure class="page-photo">
+          <picture>
+            <source srcset="/img/photos/checklist.webp" type="image/webp">
+            <img src="/img/photos/checklist.jpg" alt="Close-up of a checklist with green checkmarks" width="1880" height="1253" loading="lazy" decoding="async">
+          </picture>
+          <figcaption>Photo by Towfiqu barbhuiya on Pexels</figcaption>
+        </figure>
+
+        <section id="platforms">
+            <h2>GRC platforms</h2>
+            <p>The system-of-record layer that lives above the cloud-native tooling. The major categories in 2026:</p>
+            <ul>
+                <li><strong>Compliance-automation-first</strong> — <a href="https://www.vanta.com/" target="_blank" rel="noopener noreferrer">Vanta</a>, <a href="https://drata.com/" target="_blank" rel="noopener noreferrer">Drata</a>, <a href="https://secureframe.com/" target="_blank" rel="noopener noreferrer">Secureframe</a>, <a href="https://www.thoropass.com/" target="_blank" rel="noopener noreferrer">Thoropass</a>, <a href="https://anecdotes.ai/" target="_blank" rel="noopener noreferrer">Anecdotes</a>. Built around automated evidence collection and SOC 2 / ISO 27001 / similar attestations. Fastest path to a first SOC 2 for a SaaS company.</li>
+                <li><strong>Integrated GRC platforms</strong> — <a href="https://www.servicenow.com/products/governance-risk-and-compliance.html" target="_blank" rel="noopener noreferrer">ServiceNow GRC</a>, <a href="https://www.metricstream.com/" target="_blank" rel="noopener noreferrer">MetricStream</a>, <a href="https://www.archerirm.com/" target="_blank" rel="noopener noreferrer">Archer</a>, <a href="https://www.onetrust.com/" target="_blank" rel="noopener noreferrer">OneTrust</a>, <a href="https://www.logicgate.com/" target="_blank" rel="noopener noreferrer">LogicGate</a>, <a href="https://hyperproof.io/" target="_blank" rel="noopener noreferrer">Hyperproof</a>. Heavier enterprise tooling; broader scope (operational risk, vendor risk, third-party risk, audit management). Right when your org is large enough to have a full GRC function.</li>
+                <li><strong>Privacy-led</strong> — <a href="https://www.onetrust.com/" target="_blank" rel="noopener noreferrer">OneTrust</a>, <a href="https://trustarc.com/" target="_blank" rel="noopener noreferrer">TrustArc</a>, <a href="https://securiti.ai/" target="_blank" rel="noopener noreferrer">Securiti</a>. Strong on GDPR / CCPA / data-subject-rights workflows.</li>
+                <li><strong>Open-source / DIY</strong> — <a href="https://comply.cisotrust.com/" target="_blank" rel="noopener noreferrer">Comply</a>, internal git-based control libraries, controls-as-code in OSCAL (<a href="https://pages.nist.gov/OSCAL/" target="_blank" rel="noopener noreferrer">NIST's machine-readable control format</a>). Right when you have engineers happy to build the missing automation.</li>
+            </ul>
+            <h3>Choosing one</h3>
+            <ul>
+                <li><strong>Integration depth with your cloud(s) and identity provider.</strong> The whole value proposition is automated evidence. A platform that pulls 80% of evidence automatically is worth 2–3× one that pulls 30%.</li>
+                <li><strong>Framework coverage you actually need.</strong> Many tools support 20+ frameworks; you'll use 2–4. Pay for the depth on those, not the breadth across all.</li>
+                <li><strong>Auditor familiarity.</strong> If your target auditor has run a hundred SOC 2s on Vanta, that's a cheaper audit than the same auditor's first ServiceNow GRC engagement.</li>
+                <li><strong>Total time-to-attestation.</strong> The fastest path to a first SOC 2 Type II for a 30-person SaaS is a compliance-automation platform + an experienced auditor + 6 months of evidence collection. Anything more complex is over-engineered.</li>
+            </ul>
+        </section>
+
+        <section id="comparison">
+            <h2>AWS, Azure, and GCP side-by-side</h2>
+            <p>The native GRC-supporting capabilities each cloud ships, reduced to a one-screen reference:</p>
+            <div class="comparison-table">
+                <table>
+                    <thead>
+                        <tr>
+                            <th scope="col" class="ct-row-head">Capability</th>
+                            <th scope="col" class="ct-aws"><span class="ct-dot ct-dot-aws" aria-hidden="true"></span> AWS</th>
+                            <th scope="col" class="ct-azure"><span class="ct-dot ct-dot-azure" aria-hidden="true"></span> Azure</th>
+                            <th scope="col" class="ct-gcp"><span class="ct-dot ct-dot-gcp" aria-hidden="true"></span> GCP</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th scope="row">Policy enforcement</th>
+                            <td>Service Control Policies (SCPs), Resource Control Policies (RCPs)</td>
+                            <td>Azure Policy + Initiatives</td>
+                            <td>Organization Policy constraints</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Configuration tracking</th>
+                            <td>AWS Config, Config Rules</td>
+                            <td>Azure Resource Graph, Defender for Cloud</td>
+                            <td>Cloud Asset Inventory, Security Health Analytics</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Posture &amp; compliance</th>
+                            <td>Security Hub (CIS, PCI, NIST, AWS Foundational)</td>
+                            <td>Defender for Cloud regulatory compliance dashboard</td>
+                            <td>Security Command Center compliance posture</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Audit evidence collection</th>
+                            <td>AWS Audit Manager</td>
+                            <td>Microsoft Purview Compliance Manager</td>
+                            <td>Risk &amp; compliance as code (Assured Workloads + SCC reports)</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Regulated-workload boundary</th>
+                            <td>GovCloud, Secret Region, dedicated tenancy</td>
+                            <td>Azure Government, Sovereign Cloud offerings</td>
+                            <td>Assured Workloads (FedRAMP, IL4, ITAR), sovereign-cloud partners</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Activity audit log</th>
+                            <td>CloudTrail (org trail)</td>
+                            <td>Activity Log (subscription / mgmt group)</td>
+                            <td>Cloud Audit Logs (org-aggregated)</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Encryption controls</th>
+                            <td>KMS, CloudHSM, key policies, BYOK</td>
+                            <td>Key Vault Managed HSM, BYOK, Confidential Compute</td>
+                            <td>Cloud KMS, External Key Manager, CMEK</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Data classification</th>
+                            <td>Macie</td>
+                            <td>Purview Information Protection</td>
+                            <td>Sensitive Data Protection (DLP API)</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Identity governance</th>
+                            <td>IAM Access Analyzer, IAM Identity Center</td>
+                            <td>Entra ID Governance, Access Reviews, PIM</td>
+                            <td>IAM Recommender, Access Approval, Access Transparency</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Available attestations</th>
+                            <td><a href="https://aws.amazon.com/compliance/" target="_blank" rel="noopener noreferrer">100+ — SOC, ISO, PCI, HIPAA, FedRAMP, IRAP, C5, ENS, etc.</a></td>
+                            <td><a href="https://learn.microsoft.com/en-us/compliance/regulatory/offering-home" target="_blank" rel="noopener noreferrer">100+ — comparable global coverage</a></td>
+                            <td><a href="https://cloud.google.com/security/compliance" target="_blank" rel="noopener noreferrer">75+ — including FedRAMP High, IL4, IRAP</a></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <p>The native tools are necessary but not sufficient. Every cloud will tell you it ships everything a regulated workload needs; in practice the cross-cloud GRC platform fills the gaps between them, and the human program runs above all of it.</p>
+        </section>
+
+        <section id="roles">
+            <h2>Roles &amp; responsibilities</h2>
+            <p>GRC roles look different at different company sizes. The work doesn't disappear at small scale; it just collapses onto fewer people.</p>
+            <ul>
+                <li><strong>CISO / Head of Security.</strong> Owns the program at the executive level. Signs the security policy, owns the risk register at the board level, fronts the auditor relationship for major engagements.</li>
+                <li><strong>GRC Lead / Compliance Manager.</strong> Owns the framework mappings, the audit calendar, the evidence repository, and the relationship with auditors and 3PAOs. The role that grows in headcount as the company adds frameworks.</li>
+                <li><strong>Security Engineer (controls).</strong> Builds the technical implementations of the controls — IAM policies, encryption configs, logging pipelines, CSPM rules. Lives in the cloud platform team day-to-day; consults with GRC on framework mapping.</li>
+                <li><strong>Risk Analyst.</strong> Maintains the risk register, runs assessments (cloud, vendor, application), tracks treatments. Bigger orgs separate operational and enterprise risk; smaller orgs combine.</li>
+                <li><strong>Privacy Officer / DPO.</strong> Where GDPR or similar applies. Owns data-subject-rights processes, ROPA (Record of Processing Activities), and the privacy-impact-assessment cadence.</li>
+                <li><strong>Internal auditor.</strong> Independent line of assurance. Runs internal audits against the same frameworks external auditors will, before the external auditor arrives.</li>
+                <li><strong>External auditor / 3PAO.</strong> Third-party assurance. SOC 2 (CPA firm), ISO 27001 (registrar), FedRAMP (3PAO), PCI DSS (QSA). Not on staff; contracted.</li>
+                <li><strong>Engineering &amp; product partners.</strong> The non-GRC humans whose work the controls describe. Their cooperation is the bottleneck of any GRC program; a program adversarial to engineering eventually fails its audits because evidence stops flowing.</li>
+            </ul>
+            <p>For how these roles relate to broader cloud-security career paths, see the <a href="cloud-security-careers.html">Cloud Security Careers page</a>.</p>
+        </section>
+
+        <section id="maturity">
+            <h2>Maturity stages</h2>
+            <p>A useful staging model for a cloud GRC program:</p>
+            <div class="pillar-grid">
+                <div class="pillar-card pillar-card-stage1">
+                    <h3>Stage 1 — Written</h3>
+                    <p>Information-security policy exists and is approved. Asset inventory is partial but real. One target framework picked (usually SOC 2). Risk register is a spreadsheet. Evidence is collected manually around audit windows.</p>
+                </div>
+                <div class="pillar-card pillar-card-stage2">
+                    <h3>Stage 2 — Automated</h3>
+                    <p>GRC platform live and pulling evidence from cloud APIs, IdP, code repo, MDM. First clean SOC 2 Type II shipped. CSPM running with framework-aligned rule packs. Exception workflow defined. Auditor receives evidence via the platform, not screenshots.</p>
+                </div>
+                <div class="pillar-card pillar-card-stage3">
+                    <h3>Stage 3 — Engineered</h3>
+                    <p>Compliance-as-code in <a href="ci-cd.html">CI/CD</a> — policy violations fail the build. Controls mapped 1:1 between internal control set and 2–4 external frameworks. Risk treatments tied to engineering OKRs. Continuous-monitoring dashboard visible to executives.</p>
+                </div>
+                <div class="pillar-card pillar-card-stage4">
+                    <h3>Stage 4 — Strategic</h3>
+                    <p>GRC informs product roadmap (data-residency features, regulated-industry offerings, regional expansion). Risk-quantification methods (FAIR, monte-carlo) produce dollar-denominated risk inputs to investment decisions. The program is a competitive advantage in sales.</p>
+                </div>
+            </div>
+            <p>The skip-stage cost is real here too — an org trying to compliance-as-code without a written policy and a defined control set is automating against nothing. Sequencing matters.</p>
+        </section>
+
+        <section id="pitfalls">
+            <h2>Common pitfalls</h2>
+            <ul>
+                <li><strong>Treating GRC as a paperwork team separate from engineering.</strong> Controls live in code; the team that writes code has to be a first-class partner. Adversarial GRC ships bad audits.</li>
+                <li><strong>Single-framework tunnel vision.</strong> Pursuing SOC 2 without thinking about the ISO 27001 or PCI DSS that's coming six months later means duplicate work and two control sets. Pick the primary up front, plan the overlays.</li>
+                <li><strong>Manual evidence collection at scale.</strong> Screenshots in a Google Drive folder is a Stage 1 pattern. Past 20 controls it becomes the dominant cost of the program. Automate.</li>
+                <li><strong>Compliance theater.</strong> Controls written to pass the audit, not to reduce risk. The auditor will sign off; the breach will happen anyway. Risk-rank, then implement; never the reverse.</li>
+                <li><strong>Letting exceptions accumulate.</strong> Every exception is a risk acceptance with an expiration date. Without a workflow that surfaces expiring exceptions, you accumulate them silently until an auditor finds them. Track and review.</li>
+                <li><strong>Outsourcing the auditor relationship to the GRC platform.</strong> The platform helps; it doesn't replace the human conversation. Build the relationship with your auditor across multi-year engagements; the same firm year-over-year is dramatically cheaper than rotating.</li>
+                <li><strong>Mapping debt.</strong> Frameworks evolve (PCI DSS 4.0, ISO 27001 2022, NIST CSF 2.0, SOC 2 with revised TSC). Mapping drift is silent — every framework revision needs a planned remap.</li>
+                <li><strong>Picking a CSPM that doesn't map to your target frameworks.</strong> Every modern CSPM does — but verify the depth, not just the checkbox. Some tools map 90% of CIS but only the highlights of FedRAMP.</li>
+                <li><strong>Confusing residency with sovereignty.</strong> A region in the right country doesn't, by itself, address regulator concerns about cloud-provider personnel access, foreign legal subpoena, or sovereign-cloud requirements. Read the specific regulation; pick the matching offering.</li>
+                <li><strong>"AI will write our controls."</strong> AI is a credible assistant for drafting policy language, mapping frameworks, and summarizing evidence. It is not a substitute for the human judgment that decides what risk the org will accept. Treat as augmentation; the auditor still needs a human signatory.</li>
+            </ul>
+        </section>
+
+        <section id="further">
+            <h2>Further reading</h2>
+            <h3>Frameworks &amp; standards</h3>
+            <ul>
+                <li><a href="https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2" target="_blank" rel="noopener noreferrer">AICPA — SOC 2</a></li>
+                <li><a href="https://www.iso.org/standard/27001" target="_blank" rel="noopener noreferrer">ISO/IEC 27001:2022</a></li>
+                <li><a href="https://www.pcisecuritystandards.org/" target="_blank" rel="noopener noreferrer">PCI Security Standards Council</a></li>
+                <li><a href="https://www.fedramp.gov/" target="_blank" rel="noopener noreferrer">FedRAMP program</a></li>
+                <li><a href="https://www.nist.gov/cyberframework" target="_blank" rel="noopener noreferrer">NIST Cybersecurity Framework 2.0</a></li>
+                <li><a href="https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final" target="_blank" rel="noopener noreferrer">NIST SP 800-53 Rev 5</a></li>
+                <li><a href="https://www.cisecurity.org/cis-benchmarks" target="_blank" rel="noopener noreferrer">CIS Benchmarks</a></li>
+                <li><a href="https://cloudsecurityalliance.org/research/cloud-controls-matrix" target="_blank" rel="noopener noreferrer">CSA Cloud Controls Matrix</a></li>
+                <li><a href="https://pages.nist.gov/OSCAL/" target="_blank" rel="noopener noreferrer">NIST OSCAL — machine-readable controls</a></li>
+            </ul>
+            <h3>Policy-as-code tooling</h3>
+            <ul>
+                <li><a href="https://www.openpolicyagent.org/" target="_blank" rel="noopener noreferrer">Open Policy Agent</a></li>
+                <li><a href="https://www.conftest.dev/" target="_blank" rel="noopener noreferrer">Conftest</a></li>
+                <li><a href="https://kyverno.io/" target="_blank" rel="noopener noreferrer">Kyverno</a></li>
+                <li><a href="https://www.checkov.io/" target="_blank" rel="noopener noreferrer">Checkov</a></li>
+                <li><a href="https://aquasecurity.github.io/tfsec/" target="_blank" rel="noopener noreferrer">tfsec</a></li>
+            </ul>
+            <h3>Provider docs</h3>
+            <ul>
+                <li><a href="https://aws.amazon.com/compliance/" target="_blank" rel="noopener noreferrer">AWS Compliance Center</a></li>
+                <li><a href="https://aws.amazon.com/audit-manager/" target="_blank" rel="noopener noreferrer">AWS Audit Manager</a></li>
+                <li><a href="https://learn.microsoft.com/en-us/compliance/regulatory/offering-home" target="_blank" rel="noopener noreferrer">Microsoft Compliance offerings</a></li>
+                <li><a href="https://learn.microsoft.com/en-us/azure/governance/policy/" target="_blank" rel="noopener noreferrer">Azure Policy documentation</a></li>
+                <li><a href="https://cloud.google.com/security/compliance" target="_blank" rel="noopener noreferrer">Google Cloud Compliance</a></li>
+                <li><a href="https://cloud.google.com/assured-workloads" target="_blank" rel="noopener noreferrer">GCP Assured Workloads</a></li>
+            </ul>
+            <h3>Related CSOH pages</h3>
+            <ul>
+                <li><a href="shared-responsibility-model.html">Shared responsibility</a> — where provider obligations end and yours begin.</li>
+                <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a> — the posture-management layer GRC programs depend on.</li>
+                <li><a href="cloud-soc.html">Cloud SOC</a> — the detection / response counterpart to preventive controls.</li>
+                <li><a href="ci-cd.html">CI/CD</a> — where pre-deploy policy enforcement lives.</li>
+                <li><a href="landing-zones.html">Landing zones</a> — the foundation that makes GRC enforceable at scale.</li>
+                <li><a href="cloud-security-careers.html">Cloud security careers</a> — GRC, audit, and compliance role tracks.</li>
+                <li><a href="glossary.html">Glossary</a> — every term on this page, defined.</li>
+            </ul>
+        </section>
+
+        <section id="faq">
+            <h2>FAQ</h2>
+
+            <h3>How long does a first SOC 2 Type II take?</h3>
+            <p>For a 20–50-person SaaS using a compliance-automation platform: roughly 3–4 months to readiness, then a 6-month observation period for Type II, then 4–8 weeks of audit fieldwork. Total elapsed: 9–12 months from "we should do this" to a signed report. Skip the platform and add 50%; skip the prior auditor relationship and add another 25%.</p>
+
+            <h3>Should the GRC team report to the CISO or to Legal?</h3>
+            <p>Most cloud-native orgs put GRC inside Security under the CISO. Some larger or heavily regulated orgs (financial services, healthcare) keep the compliance function under Legal or a Chief Compliance Officer. The trade-off: Security-aligned GRC is closer to the engineering work that produces evidence; Legal-aligned GRC is closer to the contractual and regulatory side. Neither is wrong; pick the one that matches where the dependent decisions get made.</p>
+
+            <h3>Is FedRAMP worth pursuing for a commercial SaaS?</h3>
+            <p>Only if you have an actual federal-government deal that requires it. FedRAMP is 12–18+ months of work and significant ongoing cost; the math only works against revenue you can name. The path is: identify the federal customer, secure an agency sponsor or pursue JAB authorization, pick a 3PAO, and budget 18 months. "Maybe federal eventually" is a recipe for sunk cost.</p>
+
+            <h3>How does <a class="glossary-link" href="glossary.html#term-zero-trust">zero trust</a> relate to GRC?</h3>
+            <p>Zero trust is an architectural pattern; GRC is a discipline. Zero-trust controls (verify every request, least privilege, continuous validation) generate evidence GRC values (every access logged, every policy decision auditable). Most modern frameworks now reference zero-trust principles (NIST 800-207, CSF 2.0 Govern function). They reinforce each other; neither replaces the other.</p>
+
+            <h3>What's changing in cloud GRC over the next 1–2 years?</h3>
+            <p>Three forces: <em>AI assistance</em> for drafting and mapping (most GRC platforms now ship LLM-assisted evidence summarization and control-mapping), <em>regulatory expansion</em> (NIS2, DORA, AI-specific regulations like the EU AI Act), and <em>continuous-control-monitoring</em> displacing point-in-time evidence as the auditor expectation. The orgs investing in compliance-as-code now will have an easier time when the third force fully arrives.</p>
+
+            <h3>Do auditors trust automated evidence?</h3>
+            <p>Increasingly yes — and the signing auditor's familiarity with the platform you use is the bigger variable. A SOC 2 auditor who has run a hundred audits on Vanta evidence is comfortable with Vanta evidence; the same auditor's first ServiceNow GRC engagement will take longer. Talk to your auditor about evidence sources <em>before</em> you pick the platform.</p>
+        </section>
+
+        <section class="cta-section">
+            <h2>Where next</h2>
+            <ul>
+                <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a> — the live sensor under a cloud GRC program.</li>
+                <li><a href="cloud-soc.html">Cloud SOC</a> — what controls look like on the detect / respond side.</li>
+                <li><a href="ci-cd.html">CI/CD</a> — where compliance-as-code enforcement lives in the pipeline.</li>
+                <li><a href="landing-zones.html">Landing zones</a> — the architectural foundation GRC sits on.</li>
+                <li><a href="sessions.html">Friday Zoom</a> — auditor-readiness and policy-as-code come up regularly. Drop in.</li>
+            </ul>
+        </section>
+
+        <aside class="author-card" style="max-width:720px;margin:3rem auto 2rem;padding:1.5rem;border-top:2px solid var(--border-color, #e0e0e0);display:flex;align-items:flex-start;gap:1.25rem;flex-wrap:wrap;"><picture><source srcset="/img/authors/shawn-nunley.webp" type="image/webp"><img src="/img/authors/shawn-nunley.jpg" alt="Shawn Nunley" width="80" height="80" style="border-radius:50%;object-fit:cover;flex-shrink:0;" loading="lazy" decoding="async"></picture><div style="flex:1;min-width:240px;"><p style="margin:0 0 0.25rem;font-size:0.85rem;text-transform:uppercase;letter-spacing:0.05em;color:var(--text-muted, #777);">About the author</p><p style="margin:0 0 0.5rem;font-size:1.1rem;font-weight:600;"><a href="/about-shawn-nunley.html" rel="author">Shawn Nunley</a></p><p style="margin:0;color:var(--text-muted, #555);">Founder of Cloud Security Office Hours and Solutions Architect at Wiz, with 7+ years specializing in cloud security across AWS, Azure, and Google Cloud. <a href="/about-shawn-nunley.html">Read more →</a></p></div></aside>
+    </main>
+
+  <footer>
+    <div class="footer-content">
+      <div class="footer-section footer-about">
+        <h3>CSOH</h3>
+        <p>A vendor-neutral community for cloud security professionals. Weekly Zoom sessions and curated resources.</p>
+      </div>
+      <div class="footer-section">
+        <h3>Explore</h3>
+        <ul>
+          <li><a href="/learning-path.html">Learning Path</a></li>
+          <li><a href="/resources.html">Resources</a></li>
+          <li><a href="/news.html">News</a></li>
+          <li><a href="/sessions.html">Zoom Sessions</a></li>
+          <li><a href="/meetings.html">Meeting Recaps</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Connect</h3>
+        <ul>
+          <li><a href="mailto:admin@csoh.org">Contact</a></li>
+          <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
+          <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+          <li><a href="/rss.html">RSS Feed</a></li>
+          <li><a href="/contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <p>&copy; 2023-2026 Cloud Security Office Hours</p>
+      <ul class="footer-legal">
+        <li><a href="/privacy.html">Privacy</a></li>
+        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="/security-policy.html">Security</a></li>
+      </ul>
+    </div>
+  </footer>
+
+    <script src="/main.js?v=b517f39d" integrity="sha384-8/1Y6zmSmGcKtdeoSJDd4JadBZUwI1F4M7uqeUVQt8uwrLkszhyRCqoPGfhKfKA7"
+        defer></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -249,11 +249,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/kevin-mitnick.html
+++ b/kevin-mitnick.html
@@ -142,11 +142,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/kubernetes.html
+++ b/kubernetes.html
@@ -160,11 +160,12 @@
                         <li><a href="kubernetes.html" aria-current="page">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/landing-zones.html
+++ b/landing-zones.html
@@ -170,11 +170,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/learning-path.html
+++ b/learning-path.html
@@ -252,11 +252,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings.html
+++ b/meetings.html
@@ -697,11 +697,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-03-01.html
+++ b/meetings/2024-03-01.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-04-05.html
+++ b/meetings/2024-04-05.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-04-26.html
+++ b/meetings/2024-04-26.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-05-10.html
+++ b/meetings/2024-05-10.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-07-12.html
+++ b/meetings/2024-07-12.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-07-19.html
+++ b/meetings/2024-07-19.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-07-26.html
+++ b/meetings/2024-07-26.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-08-09.html
+++ b/meetings/2024-08-09.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-08-23.html
+++ b/meetings/2024-08-23.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-08-30.html
+++ b/meetings/2024-08-30.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-09-27.html
+++ b/meetings/2024-09-27.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-10-04.html
+++ b/meetings/2024-10-04.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-10-11.html
+++ b/meetings/2024-10-11.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-10-18.html
+++ b/meetings/2024-10-18.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-10-25.html
+++ b/meetings/2024-10-25.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-11-01.html
+++ b/meetings/2024-11-01.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-11-08.html
+++ b/meetings/2024-11-08.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-11-15.html
+++ b/meetings/2024-11-15.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-11-22.html
+++ b/meetings/2024-11-22.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-11-29.html
+++ b/meetings/2024-11-29.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-12-13.html
+++ b/meetings/2024-12-13.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-12-20.html
+++ b/meetings/2024-12-20.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2024-12-27.html
+++ b/meetings/2024-12-27.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-01-03.html
+++ b/meetings/2025-01-03.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-01-10.html
+++ b/meetings/2025-01-10.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-01-17.html
+++ b/meetings/2025-01-17.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-01-24.html
+++ b/meetings/2025-01-24.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-01-31.html
+++ b/meetings/2025-01-31.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-02-07.html
+++ b/meetings/2025-02-07.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-02-14.html
+++ b/meetings/2025-02-14.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-02-21.html
+++ b/meetings/2025-02-21.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-02-28.html
+++ b/meetings/2025-02-28.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-03-07.html
+++ b/meetings/2025-03-07.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-03-14.html
+++ b/meetings/2025-03-14.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-03-21.html
+++ b/meetings/2025-03-21.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-03-28.html
+++ b/meetings/2025-03-28.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-04-04.html
+++ b/meetings/2025-04-04.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-04-11.html
+++ b/meetings/2025-04-11.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-04-18.html
+++ b/meetings/2025-04-18.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-04-25.html
+++ b/meetings/2025-04-25.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-05-02.html
+++ b/meetings/2025-05-02.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-05-09.html
+++ b/meetings/2025-05-09.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-05-16.html
+++ b/meetings/2025-05-16.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-05-23.html
+++ b/meetings/2025-05-23.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-05-30.html
+++ b/meetings/2025-05-30.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-06-06.html
+++ b/meetings/2025-06-06.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-06-13.html
+++ b/meetings/2025-06-13.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-06-20.html
+++ b/meetings/2025-06-20.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-06-27.html
+++ b/meetings/2025-06-27.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-07-04.html
+++ b/meetings/2025-07-04.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-07-11.html
+++ b/meetings/2025-07-11.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-07-18.html
+++ b/meetings/2025-07-18.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-07-25.html
+++ b/meetings/2025-07-25.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-08-01.html
+++ b/meetings/2025-08-01.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-08-08.html
+++ b/meetings/2025-08-08.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-08-15.html
+++ b/meetings/2025-08-15.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-08-22.html
+++ b/meetings/2025-08-22.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-08-29.html
+++ b/meetings/2025-08-29.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-09-05.html
+++ b/meetings/2025-09-05.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-09-12.html
+++ b/meetings/2025-09-12.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-09-19.html
+++ b/meetings/2025-09-19.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-09-26.html
+++ b/meetings/2025-09-26.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-10-03.html
+++ b/meetings/2025-10-03.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-10-10.html
+++ b/meetings/2025-10-10.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-10-17.html
+++ b/meetings/2025-10-17.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-10-24.html
+++ b/meetings/2025-10-24.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-10-31.html
+++ b/meetings/2025-10-31.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-11-07.html
+++ b/meetings/2025-11-07.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-11-14.html
+++ b/meetings/2025-11-14.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-11-21.html
+++ b/meetings/2025-11-21.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-11-28.html
+++ b/meetings/2025-11-28.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-12-05.html
+++ b/meetings/2025-12-05.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-12-12.html
+++ b/meetings/2025-12-12.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-12-19.html
+++ b/meetings/2025-12-19.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2025-12-26.html
+++ b/meetings/2025-12-26.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-01-02.html
+++ b/meetings/2026-01-02.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-01-09.html
+++ b/meetings/2026-01-09.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-01-16.html
+++ b/meetings/2026-01-16.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-01-23.html
+++ b/meetings/2026-01-23.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-01-30.html
+++ b/meetings/2026-01-30.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-02-06.html
+++ b/meetings/2026-02-06.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-02-13.html
+++ b/meetings/2026-02-13.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-02-20.html
+++ b/meetings/2026-02-20.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-02-27.html
+++ b/meetings/2026-02-27.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-03-06.html
+++ b/meetings/2026-03-06.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-03-13.html
+++ b/meetings/2026-03-13.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-03-20.html
+++ b/meetings/2026-03-20.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-03-27.html
+++ b/meetings/2026-03-27.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-04-03.html
+++ b/meetings/2026-04-03.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-04-10.html
+++ b/meetings/2026-04-10.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-04-17.html
+++ b/meetings/2026-04-17.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-04-24.html
+++ b/meetings/2026-04-24.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-05-01.html
+++ b/meetings/2026-05-01.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/meetings/2026-05-08.html
+++ b/meetings/2026-05-08.html
@@ -134,11 +134,12 @@
                         <li><a href="../kubernetes.html">Kubernetes</a></li>
                         <li><a href="../serverless.html">Serverless</a></li>
                         <li><a href="../ci-cd.html">CI/CD</a></li>
+                        <li><a href="../grc.html">GRC</a></li>
                         <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>

--- a/news.html
+++ b/news.html
@@ -660,11 +660,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/presentations.html
+++ b/presentations.html
@@ -347,11 +347,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/privacy.html
+++ b/privacy.html
@@ -84,11 +84,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/resources.html
+++ b/resources.html
@@ -234,11 +234,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/rss.html
+++ b/rss.html
@@ -115,11 +115,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/security-policy.html
+++ b/security-policy.html
@@ -90,11 +90,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/serverless.html
+++ b/serverless.html
@@ -160,11 +160,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html" aria-current="page">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/sessions.html
+++ b/sessions.html
@@ -111,11 +111,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/shared-responsibility-model.html
+++ b/shared-responsibility-model.html
@@ -167,11 +167,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -218,6 +218,14 @@
     <priority>0.8</priority>
   </url>
 
+  <!-- GRC for Cloud (Governance, Risk & Compliance) - reference page -->
+  <url>
+    <loc>https://csoh.org/grc.html</loc>
+    <lastmod>2026-05-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
   <!-- GitHub Actions - Educational page on CI/CD via our workflows -->
   <url>
     <loc>https://csoh.org/github-actions.html</loc>

--- a/threat-research.html
+++ b/threat-research.html
@@ -129,11 +129,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html" aria-current="page">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>

--- a/what-is-cloud-security.html
+++ b/what-is-cloud-security.html
@@ -183,11 +183,12 @@
                         <li><a href="kubernetes.html">Kubernetes</a></li>
                         <li><a href="serverless.html">Serverless</a></li>
                         <li><a href="ci-cd.html">CI/CD</a></li>
+                        <li><a href="grc.html">GRC</a></li>
                         <li><a href="cloud-security-reading-list.html">Reading List</a></li>
                       </ul>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Research <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>


### PR DESCRIPTION
## Summary
- **New topic page**: `grc.html` — vendor-neutral guide to GRC for cloud (Governance / Risk / Compliance pillars, framework landscape, policy-as-code, continuous compliance, audit evidence, AWS/Azure/GCP comparison, roles, maturity stages, pitfalls, FAQ). Schema markup includes Article, BreadcrumbList, and FAQPage.
- **Topics dropdown**: GRC link added after CI/CD across every nav-bearing page (root, `breaches/`, `portfolio/`, `meetings/`), using relative `../` paths where appropriate. Sitemap updated.
- **Nav rename**: "Threat Research" dropdown button → "Detection and Response" across all 148 pages. The dropdown menu items (Threat Research, Breach Kill Chains, Cloud SOC, CTFs) are unchanged — only the parent button label.

## Test plan
- [ ] Open `grc.html` locally and confirm hero, illustration, TOC anchors, FAQ accordion, and footer all render correctly
- [ ] Confirm the Topics dropdown now contains a GRC link on a sampling of pages (`index.html`, `cloud-soc.html`, `breaches/capital-one.html`, `meetings/2026-05-08.html`)
- [ ] Confirm the renamed "Detection and Response" dropdown still opens to Threat Research / Breach Kill Chains / Cloud SOC / CTFs
- [ ] Lychee CI passes on the new page
- [ ] `sitemap.xml` includes the new `grc.html` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)