### PR TITLE
Remove About Shawn from About dropdown

### DIFF
--- a/403.html
+++ b/403.html
@@ -106,7 +106,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/403.html
+++ b/403.html
@@ -11,7 +11,7 @@
     <link rel="manifest" href="/manifest.json">
     <link rel="author" type="text/plain" href="/humans.txt">
     <meta name="theme-color" content="#2c3e50">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d" integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="stylesheet" href="/style.css?v=81490698" integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
   <noscript><style>.js-enabled header nav{display:block !important}</style></noscript>
 </head>
@@ -31,73 +31,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -139,11 +153,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -152,17 +166,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/404.html
+++ b/404.html
@@ -107,7 +107,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/404.html
+++ b/404.html
@@ -11,7 +11,7 @@
     <link rel="manifest" href="/manifest.json">
     <link rel="author" type="text/plain" href="/humans.txt">
     <meta name="theme-color" content="#2c3e50">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d" integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="stylesheet" href="/style.css?v=81490698" integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
 
   <noscript><style>.js-enabled header nav{display:block !important}</style></noscript>
@@ -32,73 +32,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -207,11 +221,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -220,17 +234,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/about-shawn-nunley.html
+++ b/about-shawn-nunley.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -134,73 +134,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
+                        <li><a href="about-shawn-nunley.html" aria-current="page">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
-                      </ul>
-                    </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -433,11 +447,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -446,17 +460,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/about-shawn-nunley.html
+++ b/about-shawn-nunley.html
@@ -207,9 +207,8 @@
                       </div>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html" aria-current="page">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/ai-learning.html
+++ b/ai-learning.html
@@ -36,10 +36,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -223,73 +223,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html" aria-current="page">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html" aria-current="page">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -728,11 +742,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -741,17 +755,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/ai-learning.html
+++ b/ai-learning.html
@@ -298,7 +298,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/breach-timeline.html
+++ b/breach-timeline.html
@@ -244,7 +244,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/breach-timeline.html
+++ b/breach-timeline.html
@@ -35,10 +35,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
     <link rel="stylesheet" href="/breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">
@@ -169,73 +169,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -512,11 +526,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -525,17 +539,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/breaches/capital-one.html
+++ b/breaches/capital-one.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
     <link rel="stylesheet" href="/breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">
@@ -108,73 +108,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -361,11 +375,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -374,17 +388,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/breaches/capital-one.html
+++ b/breaches/capital-one.html
@@ -183,7 +183,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/breaches/lastpass.html
+++ b/breaches/lastpass.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
     <link rel="stylesheet" href="/breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">
@@ -108,73 +108,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -373,11 +387,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -386,17 +400,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/breaches/lastpass.html
+++ b/breaches/lastpass.html
@@ -183,7 +183,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/breaches/microsoft-sas-leak.html
+++ b/breaches/microsoft-sas-leak.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
     <link rel="stylesheet" href="/breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">
@@ -108,73 +108,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -330,11 +344,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -343,17 +357,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/breaches/microsoft-sas-leak.html
+++ b/breaches/microsoft-sas-leak.html
@@ -183,7 +183,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/breaches/mitnick-novell.html
+++ b/breaches/mitnick-novell.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
     <link rel="stylesheet" href="/breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">
@@ -108,73 +108,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -397,11 +411,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -410,17 +424,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/breaches/mitnick-novell.html
+++ b/breaches/mitnick-novell.html
@@ -183,7 +183,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/breaches/promptware.html
+++ b/breaches/promptware.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
     <link rel="stylesheet" href="/breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">
@@ -108,73 +108,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -442,11 +456,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -455,17 +469,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/breaches/promptware.html
+++ b/breaches/promptware.html
@@ -183,7 +183,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/breaches/scattered-spider-mgm.html
+++ b/breaches/scattered-spider-mgm.html
@@ -183,7 +183,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/breaches/scattered-spider-mgm.html
+++ b/breaches/scattered-spider-mgm.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
     <link rel="stylesheet" href="/breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">
@@ -108,73 +108,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -438,11 +452,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -451,17 +465,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/breaches/snowflake-unc5537.html
+++ b/breaches/snowflake-unc5537.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
     <link rel="stylesheet" href="/breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">
@@ -108,73 +108,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -347,11 +361,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -360,17 +374,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/breaches/snowflake-unc5537.html
+++ b/breaches/snowflake-unc5537.html
@@ -183,7 +183,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/breaches/solarwinds.html
+++ b/breaches/solarwinds.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
     <link rel="stylesheet" href="/breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">
@@ -108,73 +108,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -372,11 +386,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -385,17 +399,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/breaches/solarwinds.html
+++ b/breaches/solarwinds.html
@@ -183,7 +183,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/breaches/storm-0558.html
+++ b/breaches/storm-0558.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
     <link rel="stylesheet" href="/breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">
@@ -108,73 +108,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -362,11 +376,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -375,17 +389,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/breaches/storm-0558.html
+++ b/breaches/storm-0558.html
@@ -183,7 +183,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/breaches/uber.html
+++ b/breaches/uber.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
     <link rel="stylesheet" href="/breach-timeline.css?v=29fbd6a9" integrity="sha384-WrezLhCC8Bdnk6bhRviNG3f7jv+K1IW8/RCNel8OBIyPAd9wiZ4IMtSBG5Nu6Wja">
 
     <script type="application/ld+json">
@@ -108,73 +108,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html" aria-current="page">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -366,11 +380,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -379,17 +393,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/breaches/uber.html
+++ b/breaches/uber.html
@@ -183,7 +183,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/chat-resources.html
+++ b/chat-resources.html
@@ -106,7 +106,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/chat-resources.html
+++ b/chat-resources.html
@@ -12,7 +12,7 @@
     <link rel="manifest" href="/manifest.json">
     <link rel="author" type="text/plain" href="/humans.txt">
     <meta name="theme-color" content="#2c3e50">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d" integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="stylesheet" href="/style.css?v=81490698" integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
   <noscript><style>.js-enabled header nav{display:block !important}</style></noscript>
 </head>
 
@@ -31,73 +31,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html" aria-current="page">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html" aria-current="page">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -6582,11 +6596,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -6595,17 +6609,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/ci-cd.html
+++ b/ci-cd.html
@@ -218,7 +218,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/ci-cd.html
+++ b/ci-cd.html
@@ -34,10 +34,10 @@
     <link rel="preconnect" href="https://github.com" crossorigin>
     <link rel="dns-prefetch" href="https://github.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -143,73 +143,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html" aria-current="page">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html" aria-current="page">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -729,11 +743,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -742,17 +756,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/cloud-deployment.html
+++ b/cloud-deployment.html
@@ -167,7 +167,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/cloud-deployment.html
+++ b/cloud-deployment.html
@@ -33,10 +33,10 @@
     <link rel="preconnect" href="https://github.com" crossorigin>
     <link rel="dns-prefetch" href="https://github.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -92,73 +92,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html" aria-current="page">How We Deploy to GCP</a></li>
-                      </ul>
-                    </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -848,11 +862,11 @@ OR protoPayload.@type="type.googleapis.com/google.cloud.audit.AuditLog"</pre>
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -861,17 +875,24 @@ OR protoPayload.@type="type.googleapis.com/google.cloud.audit.AuditLog"</pre>
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/cloud-security-best-practices.html
+++ b/cloud-security-best-practices.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -108,73 +108,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html" aria-current="page">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html" aria-current="page">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -677,11 +691,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -690,17 +704,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/cloud-security-best-practices.html
+++ b/cloud-security-best-practices.html
@@ -183,7 +183,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/cloud-security-careers.html
+++ b/cloud-security-careers.html
@@ -36,10 +36,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -145,73 +145,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html" aria-current="page">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html" aria-current="page">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -578,11 +592,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -591,17 +605,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/cloud-security-careers.html
+++ b/cloud-security-careers.html
@@ -220,7 +220,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/cloud-security-certifications.html
+++ b/cloud-security-certifications.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -289,73 +289,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html" aria-current="page">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html" aria-current="page">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -604,11 +618,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -617,17 +631,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/cloud-security-certifications.html
+++ b/cloud-security-certifications.html
@@ -364,7 +364,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/cloud-security-degree-programs.html
+++ b/cloud-security-degree-programs.html
@@ -228,7 +228,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/cloud-security-degree-programs.html
+++ b/cloud-security-degree-programs.html
@@ -36,10 +36,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -153,73 +153,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html" aria-current="page">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html" aria-current="page">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -602,11 +616,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -615,17 +629,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/cloud-security-home-lab.html
+++ b/cloud-security-home-lab.html
@@ -213,7 +213,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/cloud-security-home-lab.html
+++ b/cloud-security-home-lab.html
@@ -36,10 +36,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -138,73 +138,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html" aria-current="page">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html" aria-current="page">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -630,11 +644,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -643,17 +657,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/cloud-security-portfolio-projects.html
+++ b/cloud-security-portfolio-projects.html
@@ -36,10 +36,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -92,73 +92,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html" aria-current="page">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html" aria-current="page">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -328,11 +342,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -341,17 +355,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/cloud-security-portfolio-projects.html
+++ b/cloud-security-portfolio-projects.html
@@ -167,7 +167,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/cloud-security-reading-list.html
+++ b/cloud-security-reading-list.html
@@ -180,7 +180,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/cloud-security-reading-list.html
+++ b/cloud-security-reading-list.html
@@ -36,10 +36,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -105,73 +105,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html" aria-current="page">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html" aria-current="page">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -618,11 +632,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -631,17 +645,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/cloud-soc.html
+++ b/cloud-soc.html
@@ -34,10 +34,10 @@
     <link rel="preconnect" href="https://github.com" crossorigin>
     <link rel="dns-prefetch" href="https://github.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -133,73 +133,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html" aria-current="page">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -808,11 +822,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -821,17 +835,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/cloud-soc.html
+++ b/cloud-soc.html
@@ -208,7 +208,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -35,10 +35,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
   <noscript><style>.js-enabled header nav{display:block !important}</style></noscript>
 </head>
 
@@ -57,73 +57,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -247,11 +261,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -260,17 +274,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -132,7 +132,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/community.html
+++ b/community.html
@@ -36,10 +36,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -93,73 +93,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html" aria-current="page">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html" aria-current="page">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -301,11 +315,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -314,17 +328,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/community.html
+++ b/community.html
@@ -168,7 +168,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/conferences.html
+++ b/conferences.html
@@ -347,7 +347,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/conferences.html
+++ b/conferences.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -272,73 +272,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html" aria-current="page">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html" aria-current="page">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -839,11 +853,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -852,17 +866,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/containers.html
+++ b/containers.html
@@ -208,7 +208,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/containers.html
+++ b/containers.html
@@ -34,10 +34,10 @@
     <link rel="preconnect" href="https://github.com" crossorigin>
     <link rel="dns-prefetch" href="https://github.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -133,73 +133,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html" aria-current="page">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html" aria-current="page">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -735,11 +749,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -748,17 +762,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/contribute-resources.html
+++ b/contribute-resources.html
@@ -158,7 +158,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html" aria-current="page">Add a Resource</a></li>
                       </ul>

--- a/contribute-resources.html
+++ b/contribute-resources.html
@@ -38,10 +38,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
 
 
@@ -83,73 +83,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html" aria-current="page">Add a Resource</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
-                      </ul>
-                    </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -540,11 +554,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -553,17 +567,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/contribute.html
+++ b/contribute.html
@@ -159,7 +159,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html" aria-current="page">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/contribute.html
+++ b/contribute.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
 
 
@@ -84,73 +84,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="contribute.html" aria-current="page">Contribute Overview</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html" aria-current="page">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
-                      </ul>
-                    </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -824,11 +838,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -837,17 +851,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/cspm-vs-cnapp.html
+++ b/cspm-vs-cnapp.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -140,73 +140,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html" aria-current="page">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html" aria-current="page">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -618,11 +632,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -631,17 +645,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/cspm-vs-cnapp.html
+++ b/cspm-vs-cnapp.html
@@ -215,7 +215,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/ctfs.html
+++ b/ctfs.html
@@ -432,7 +432,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/ctfs.html
+++ b/ctfs.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <style>
         /* Wiz Championship calendar layout */
@@ -357,73 +357,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html" aria-current="page">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -1161,11 +1175,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -1174,17 +1188,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/faq.html
+++ b/faq.html
@@ -191,7 +191,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/faq.html
+++ b/faq.html
@@ -37,10 +37,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -116,73 +116,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html" aria-current="page">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html" aria-current="page">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
-                      </ul>
-                    </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -438,11 +452,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -451,17 +465,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/github-actions.html
+++ b/github-actions.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -108,73 +108,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html" aria-current="page">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
-                      </ul>
-                    </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -733,11 +747,11 @@ done</pre></div>
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -746,17 +760,24 @@ done</pre></div>
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/github-actions.html
+++ b/github-actions.html
@@ -183,7 +183,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/glossary.html
+++ b/glossary.html
@@ -144,7 +144,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/glossary.html
+++ b/glossary.html
@@ -37,10 +37,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -69,73 +69,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html" aria-current="page">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="glossary.html" aria-current="page">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
-                      </ul>
-                    </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -1046,11 +1060,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -1059,17 +1073,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/grc.html
+++ b/grc.html
@@ -216,7 +216,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/grc.html
+++ b/grc.html
@@ -34,10 +34,10 @@
     <link rel="preconnect" href="https://github.com" crossorigin>
     <link rel="dns-prefetch" href="https://github.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -141,73 +141,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html" aria-current="page">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html" aria-current="page">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -797,11 +811,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -810,17 +824,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/index.html
+++ b/index.html
@@ -44,11 +44,11 @@
     imagesrcset="/img/photos/homepage-team-800.webp 800w, /img/photos/homepage-team-1200.webp 1200w, /img/photos/homepage-team.webp 1880w"
     imagesizes="(max-width: 768px) 100vw, (max-width: 1200px) 1136px, 1136px" fetchpriority="high">
 
-  <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-    integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+  <link rel="preload" href="/style.css?v=81490698" as="style"
+    integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
-  <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-    integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+  <link rel="stylesheet" href="/style.css?v=81490698"
+    integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
   <!-- Structured Data for SEO -->
   <script type="application/ld+json">
@@ -222,73 +222,87 @@
       <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html" aria-current="page">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
     </div>
@@ -633,11 +647,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -646,17 +660,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/index.html
+++ b/index.html
@@ -297,7 +297,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/kevin-mitnick.html
+++ b/kevin-mitnick.html
@@ -92,10 +92,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
   <noscript><style>.js-enabled header nav{display:block !important}</style></noscript>
 </head>
@@ -115,73 +115,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -392,11 +406,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -405,17 +419,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/kevin-mitnick.html
+++ b/kevin-mitnick.html
@@ -190,7 +190,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/kubernetes.html
+++ b/kubernetes.html
@@ -208,7 +208,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/kubernetes.html
+++ b/kubernetes.html
@@ -34,10 +34,10 @@
     <link rel="preconnect" href="https://github.com" crossorigin>
     <link rel="dns-prefetch" href="https://github.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -133,73 +133,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html" aria-current="page">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html" aria-current="page">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -783,11 +797,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -796,17 +810,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/landing-zones.html
+++ b/landing-zones.html
@@ -34,10 +34,10 @@
     <link rel="preconnect" href="https://github.com" crossorigin>
     <link rel="dns-prefetch" href="https://github.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -143,73 +143,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html" aria-current="page">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html" aria-current="page">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -664,11 +678,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -677,17 +691,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/landing-zones.html
+++ b/landing-zones.html
@@ -218,7 +218,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/learning-path.html
+++ b/learning-path.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -225,73 +225,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html" aria-current="page">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html" aria-current="page">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -590,11 +604,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -603,17 +617,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/learning-path.html
+++ b/learning-path.html
@@ -300,7 +300,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings.html
+++ b/meetings.html
@@ -745,7 +745,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings.html
+++ b/meetings.html
@@ -35,10 +35,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -670,73 +670,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -1560,11 +1574,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -1573,17 +1587,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-03-01.html
+++ b/meetings/2024-03-01.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-03-01.html
+++ b/meetings/2024-03-01.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -235,11 +249,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -248,17 +262,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-04-05.html
+++ b/meetings/2024-04-05.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-04-05.html
+++ b/meetings/2024-04-05.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -236,11 +250,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -249,17 +263,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-04-26.html
+++ b/meetings/2024-04-26.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-04-26.html
+++ b/meetings/2024-04-26.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -228,11 +242,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -241,17 +255,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-05-10.html
+++ b/meetings/2024-05-10.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -230,11 +244,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -243,17 +257,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-05-10.html
+++ b/meetings/2024-05-10.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-07-12.html
+++ b/meetings/2024-07-12.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-07-12.html
+++ b/meetings/2024-07-12.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-07-19.html
+++ b/meetings/2024-07-19.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -238,11 +252,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -251,17 +265,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-07-19.html
+++ b/meetings/2024-07-19.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-07-26.html
+++ b/meetings/2024-07-26.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -230,11 +244,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -243,17 +257,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-07-26.html
+++ b/meetings/2024-07-26.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-08-09.html
+++ b/meetings/2024-08-09.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-08-09.html
+++ b/meetings/2024-08-09.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -240,11 +254,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -253,17 +267,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-08-23.html
+++ b/meetings/2024-08-23.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-08-23.html
+++ b/meetings/2024-08-23.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -240,11 +254,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -253,17 +267,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-08-30.html
+++ b/meetings/2024-08-30.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-08-30.html
+++ b/meetings/2024-08-30.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-09-27.html
+++ b/meetings/2024-09-27.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-09-27.html
+++ b/meetings/2024-09-27.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-10-04.html
+++ b/meetings/2024-10-04.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -230,11 +244,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -243,17 +257,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-10-04.html
+++ b/meetings/2024-10-04.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-10-11.html
+++ b/meetings/2024-10-11.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-10-11.html
+++ b/meetings/2024-10-11.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-10-18.html
+++ b/meetings/2024-10-18.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-10-18.html
+++ b/meetings/2024-10-18.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-10-25.html
+++ b/meetings/2024-10-25.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-10-25.html
+++ b/meetings/2024-10-25.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -228,11 +242,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -241,17 +255,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-11-01.html
+++ b/meetings/2024-11-01.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-11-01.html
+++ b/meetings/2024-11-01.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -228,11 +242,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -241,17 +255,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-11-08.html
+++ b/meetings/2024-11-08.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-11-08.html
+++ b/meetings/2024-11-08.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-11-15.html
+++ b/meetings/2024-11-15.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-11-15.html
+++ b/meetings/2024-11-15.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-11-22.html
+++ b/meetings/2024-11-22.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-11-22.html
+++ b/meetings/2024-11-22.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -236,11 +250,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -249,17 +263,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-11-29.html
+++ b/meetings/2024-11-29.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -238,11 +252,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -251,17 +265,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-11-29.html
+++ b/meetings/2024-11-29.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-12-13.html
+++ b/meetings/2024-12-13.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-12-13.html
+++ b/meetings/2024-12-13.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -236,11 +250,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -249,17 +263,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-12-20.html
+++ b/meetings/2024-12-20.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2024-12-20.html
+++ b/meetings/2024-12-20.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -236,11 +250,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -249,17 +263,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-12-27.html
+++ b/meetings/2024-12-27.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2024-12-27.html
+++ b/meetings/2024-12-27.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-01-03.html
+++ b/meetings/2025-01-03.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -238,11 +252,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -251,17 +265,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-01-03.html
+++ b/meetings/2025-01-03.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-01-10.html
+++ b/meetings/2025-01-10.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -230,11 +244,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -243,17 +257,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-01-10.html
+++ b/meetings/2025-01-10.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-01-17.html
+++ b/meetings/2025-01-17.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-01-17.html
+++ b/meetings/2025-01-17.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-01-24.html
+++ b/meetings/2025-01-24.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -230,11 +244,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -243,17 +257,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-01-24.html
+++ b/meetings/2025-01-24.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-01-31.html
+++ b/meetings/2025-01-31.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-01-31.html
+++ b/meetings/2025-01-31.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-02-07.html
+++ b/meetings/2025-02-07.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-02-07.html
+++ b/meetings/2025-02-07.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-02-14.html
+++ b/meetings/2025-02-14.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -230,11 +244,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -243,17 +257,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-02-14.html
+++ b/meetings/2025-02-14.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-02-21.html
+++ b/meetings/2025-02-21.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-02-21.html
+++ b/meetings/2025-02-21.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -226,11 +240,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -239,17 +253,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-02-28.html
+++ b/meetings/2025-02-28.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-02-28.html
+++ b/meetings/2025-02-28.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-03-07.html
+++ b/meetings/2025-03-07.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-03-07.html
+++ b/meetings/2025-03-07.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-03-14.html
+++ b/meetings/2025-03-14.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-03-14.html
+++ b/meetings/2025-03-14.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-03-21.html
+++ b/meetings/2025-03-21.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-03-21.html
+++ b/meetings/2025-03-21.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-03-28.html
+++ b/meetings/2025-03-28.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-03-28.html
+++ b/meetings/2025-03-28.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-04-04.html
+++ b/meetings/2025-04-04.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-04-04.html
+++ b/meetings/2025-04-04.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-04-11.html
+++ b/meetings/2025-04-11.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-04-11.html
+++ b/meetings/2025-04-11.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -236,11 +250,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -249,17 +263,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-04-18.html
+++ b/meetings/2025-04-18.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-04-18.html
+++ b/meetings/2025-04-18.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-04-25.html
+++ b/meetings/2025-04-25.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-04-25.html
+++ b/meetings/2025-04-25.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-05-02.html
+++ b/meetings/2025-05-02.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-05-02.html
+++ b/meetings/2025-05-02.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-05-09.html
+++ b/meetings/2025-05-09.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-05-09.html
+++ b/meetings/2025-05-09.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-05-16.html
+++ b/meetings/2025-05-16.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -230,11 +244,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -243,17 +257,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-05-16.html
+++ b/meetings/2025-05-16.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-05-23.html
+++ b/meetings/2025-05-23.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-05-23.html
+++ b/meetings/2025-05-23.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -228,11 +242,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -241,17 +255,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-05-30.html
+++ b/meetings/2025-05-30.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-05-30.html
+++ b/meetings/2025-05-30.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-06-06.html
+++ b/meetings/2025-06-06.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-06-06.html
+++ b/meetings/2025-06-06.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-06-13.html
+++ b/meetings/2025-06-13.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-06-13.html
+++ b/meetings/2025-06-13.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-06-20.html
+++ b/meetings/2025-06-20.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -230,11 +244,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -243,17 +257,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-06-20.html
+++ b/meetings/2025-06-20.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-06-27.html
+++ b/meetings/2025-06-27.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-06-27.html
+++ b/meetings/2025-06-27.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -236,11 +250,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -249,17 +263,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-07-04.html
+++ b/meetings/2025-07-04.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -238,11 +252,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -251,17 +265,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-07-04.html
+++ b/meetings/2025-07-04.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-07-11.html
+++ b/meetings/2025-07-11.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -230,11 +244,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -243,17 +257,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-07-11.html
+++ b/meetings/2025-07-11.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-07-18.html
+++ b/meetings/2025-07-18.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -238,11 +252,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -251,17 +265,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-07-18.html
+++ b/meetings/2025-07-18.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-07-25.html
+++ b/meetings/2025-07-25.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-07-25.html
+++ b/meetings/2025-07-25.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-08-01.html
+++ b/meetings/2025-08-01.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-08-01.html
+++ b/meetings/2025-08-01.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-08-08.html
+++ b/meetings/2025-08-08.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-08-08.html
+++ b/meetings/2025-08-08.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -240,11 +254,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -253,17 +267,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-08-15.html
+++ b/meetings/2025-08-15.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-08-15.html
+++ b/meetings/2025-08-15.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-08-22.html
+++ b/meetings/2025-08-22.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-08-22.html
+++ b/meetings/2025-08-22.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-08-29.html
+++ b/meetings/2025-08-29.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-08-29.html
+++ b/meetings/2025-08-29.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-09-05.html
+++ b/meetings/2025-09-05.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-09-05.html
+++ b/meetings/2025-09-05.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-09-12.html
+++ b/meetings/2025-09-12.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-09-12.html
+++ b/meetings/2025-09-12.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-09-19.html
+++ b/meetings/2025-09-19.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-09-19.html
+++ b/meetings/2025-09-19.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-09-26.html
+++ b/meetings/2025-09-26.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-09-26.html
+++ b/meetings/2025-09-26.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -236,11 +250,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -249,17 +263,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-10-03.html
+++ b/meetings/2025-10-03.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -230,11 +244,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -243,17 +257,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-10-03.html
+++ b/meetings/2025-10-03.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-10-10.html
+++ b/meetings/2025-10-10.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-10-10.html
+++ b/meetings/2025-10-10.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-10-17.html
+++ b/meetings/2025-10-17.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -230,11 +244,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -243,17 +257,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-10-17.html
+++ b/meetings/2025-10-17.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-10-24.html
+++ b/meetings/2025-10-24.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-10-24.html
+++ b/meetings/2025-10-24.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-10-31.html
+++ b/meetings/2025-10-31.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-10-31.html
+++ b/meetings/2025-10-31.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -226,11 +240,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -239,17 +253,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-11-07.html
+++ b/meetings/2025-11-07.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-11-07.html
+++ b/meetings/2025-11-07.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-11-14.html
+++ b/meetings/2025-11-14.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -230,11 +244,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -243,17 +257,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-11-14.html
+++ b/meetings/2025-11-14.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-11-21.html
+++ b/meetings/2025-11-21.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-11-21.html
+++ b/meetings/2025-11-21.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-11-28.html
+++ b/meetings/2025-11-28.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-11-28.html
+++ b/meetings/2025-11-28.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-12-05.html
+++ b/meetings/2025-12-05.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -230,11 +244,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -243,17 +257,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-12-05.html
+++ b/meetings/2025-12-05.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-12-12.html
+++ b/meetings/2025-12-12.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-12-12.html
+++ b/meetings/2025-12-12.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-12-19.html
+++ b/meetings/2025-12-19.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -230,11 +244,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -243,17 +257,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-12-19.html
+++ b/meetings/2025-12-19.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2025-12-26.html
+++ b/meetings/2025-12-26.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -238,11 +252,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -251,17 +265,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2025-12-26.html
+++ b/meetings/2025-12-26.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-01-02.html
+++ b/meetings/2026-01-02.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-01-02.html
+++ b/meetings/2026-01-02.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -236,11 +250,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -249,17 +263,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-01-09.html
+++ b/meetings/2026-01-09.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-01-09.html
+++ b/meetings/2026-01-09.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -242,11 +256,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -255,17 +269,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-01-16.html
+++ b/meetings/2026-01-16.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -230,11 +244,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -243,17 +257,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-01-16.html
+++ b/meetings/2026-01-16.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-01-23.html
+++ b/meetings/2026-01-23.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -224,11 +238,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -237,17 +251,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-01-23.html
+++ b/meetings/2026-01-23.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-01-30.html
+++ b/meetings/2026-01-30.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-01-30.html
+++ b/meetings/2026-01-30.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -240,11 +254,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -253,17 +267,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-02-06.html
+++ b/meetings/2026-02-06.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -237,11 +251,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -250,17 +264,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-02-06.html
+++ b/meetings/2026-02-06.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-02-13.html
+++ b/meetings/2026-02-13.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-02-13.html
+++ b/meetings/2026-02-13.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -240,11 +254,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -253,17 +267,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-02-20.html
+++ b/meetings/2026-02-20.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -237,11 +251,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -250,17 +264,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-02-20.html
+++ b/meetings/2026-02-20.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-02-27.html
+++ b/meetings/2026-02-27.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-02-27.html
+++ b/meetings/2026-02-27.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -232,11 +246,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -245,17 +259,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-03-06.html
+++ b/meetings/2026-03-06.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-03-06.html
+++ b/meetings/2026-03-06.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -243,11 +257,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -256,17 +270,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-03-13.html
+++ b/meetings/2026-03-13.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-03-13.html
+++ b/meetings/2026-03-13.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-03-20.html
+++ b/meetings/2026-03-20.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -238,11 +252,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -251,17 +265,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-03-20.html
+++ b/meetings/2026-03-20.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-03-27.html
+++ b/meetings/2026-03-27.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-03-27.html
+++ b/meetings/2026-03-27.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -240,11 +254,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -253,17 +267,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-04-03.html
+++ b/meetings/2026-04-03.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -252,11 +266,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -265,17 +279,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-04-03.html
+++ b/meetings/2026-04-03.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-04-10.html
+++ b/meetings/2026-04-10.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-04-10.html
+++ b/meetings/2026-04-10.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -246,11 +260,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -259,17 +273,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-04-17.html
+++ b/meetings/2026-04-17.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-04-17.html
+++ b/meetings/2026-04-17.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -240,11 +254,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -253,17 +267,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-04-24.html
+++ b/meetings/2026-04-24.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -234,11 +248,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -247,17 +261,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-04-24.html
+++ b/meetings/2026-04-24.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-05-01.html
+++ b/meetings/2026-05-01.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-05-01.html
+++ b/meetings/2026-05-01.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -240,11 +254,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -253,17 +267,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/meetings/2026-05-08.html
+++ b/meetings/2026-05-08.html
@@ -182,7 +182,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/meetings/2026-05-08.html
+++ b/meetings/2026-05-08.html
@@ -33,10 +33,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -107,73 +107,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="../learning-path.html">Learning Path</a></li>
-                        <li><a href="../ai-learning.html">AI Learning</a></li>
-                        <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="../cloud-security-careers.html">Careers</a></li>
-                        <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="../resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="../glossary.html">Glossary</a></li>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="../landing-zones.html">Landing Zones</a></li>
-                        <li><a href="../containers.html">Containers</a></li>
-                        <li><a href="../kubernetes.html">Kubernetes</a></li>
-                        <li><a href="../serverless.html">Serverless</a></li>
-                        <li><a href="../ci-cd.html">CI/CD</a></li>
-                        <li><a href="../grc.html">GRC</a></li>
-                        <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
                         <li><a href="../threat-research.html">Threat Research</a></li>
                         <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="../cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="../ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../sessions.html">Zoom Sessions</a></li>
-                        <li><a href="../community.html">Community &amp; Signal</a></li>
-                        <li><a href="../conferences.html">Conferences</a></li>
-                        <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
-                        <li><a href="../presentations.html">Presentations</a></li>
-                        <li><a href="../chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="../contribute.html">Contribute Overview</a></li>
-                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="../community.html">Community &amp; Signal</a></li>
+                            <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="../meetings.html" aria-current="page">Meeting Recaps</a></li>
+                            <li><a href="../presentations.html">Presentations</a></li>
+                            <li><a href="../chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../glossary.html">Glossary</a></li>
-                        <li><a href="../faq.html">FAQ</a></li>
-                        <li><a href="../github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="../cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -227,11 +241,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -240,17 +254,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/news.html
+++ b/news.html
@@ -708,7 +708,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/news.html
+++ b/news.html
@@ -42,10 +42,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <!-- Structured Data - Breadcrumb -->
     <script type="application/ld+json">
@@ -633,73 +633,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html" aria-current="page">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html" aria-current="page">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -2119,11 +2133,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -2132,17 +2146,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/portfolio/aws-org-scps.html
+++ b/portfolio/aws-org-scps.html
@@ -32,10 +32,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -89,55 +89,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li class="has-dropdown">
-                        <button class="dropdown-toggle active" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
                             <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                            <li><a href="../learning-path.html">Learning Path</a></li>
-                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                            <li><a href="../cloud-security-careers.html">Careers</a></li>
-                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
                             <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
                             <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                            <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ctfs.html">CTFs</a></li>
-                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                            <li><a href="../github-actions.html">GitHub Actions</a></li>
                             <li><a href="../glossary.html">Glossary</a></li>
-                        </ul>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html" aria-current="page">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Defend <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../news.html">News</a></li>
-                            <li><a href="../threat-research.html">Threat Research</a></li>
-                            <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
-                        </ul>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
+                        <li><a href="../threat-research.html">Threat Research</a></li>
+                        <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
+                        <li><a href="../cloud-soc.html">Cloud SOC</a></li>
+                        <li><a href="../ctfs.html">CTFs</a></li>
+                      </ul>
                     </li>
-                    <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../sessions.html">Zoom Sessions</a></li>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
                             <li><a href="../community.html">Community &amp; Signal</a></li>
                             <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
                             <li><a href="../meetings.html">Meeting Recaps</a></li>
                             <li><a href="../presentations.html">Presentations</a></li>
                             <li><a href="../chat-resources.html">Chat Resources</a></li>
-                        </ul>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../contribute.html">Contribute Overview</a></li>
-                            <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                        </ul>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
+                      </ul>
                     </li>
-                    <li><a href="../faq.html">FAQ</a></li>
-                    <li><a href="../index.html#about">About</a></li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -287,11 +319,11 @@ resource "aws_organizations_organizational_unit" "workloads" {
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -300,17 +332,24 @@ resource "aws_organizations_organizational_unit" "workloads" {
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/portfolio/aws-org-scps.html
+++ b/portfolio/aws-org-scps.html
@@ -164,7 +164,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/portfolio/cloudgoat.html
+++ b/portfolio/cloudgoat.html
@@ -164,7 +164,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/portfolio/cloudgoat.html
+++ b/portfolio/cloudgoat.html
@@ -32,10 +32,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -89,55 +89,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li class="has-dropdown">
-                        <button class="dropdown-toggle active" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
                             <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                            <li><a href="../learning-path.html">Learning Path</a></li>
-                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                            <li><a href="../cloud-security-careers.html">Careers</a></li>
-                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
                             <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
                             <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                            <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ctfs.html">CTFs</a></li>
-                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                            <li><a href="../github-actions.html">GitHub Actions</a></li>
                             <li><a href="../glossary.html">Glossary</a></li>
-                        </ul>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html" aria-current="page">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Defend <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../news.html">News</a></li>
-                            <li><a href="../threat-research.html">Threat Research</a></li>
-                            <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
-                        </ul>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
+                        <li><a href="../threat-research.html">Threat Research</a></li>
+                        <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
+                        <li><a href="../cloud-soc.html">Cloud SOC</a></li>
+                        <li><a href="../ctfs.html">CTFs</a></li>
+                      </ul>
                     </li>
-                    <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../sessions.html">Zoom Sessions</a></li>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
                             <li><a href="../community.html">Community &amp; Signal</a></li>
                             <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
                             <li><a href="../meetings.html">Meeting Recaps</a></li>
                             <li><a href="../presentations.html">Presentations</a></li>
                             <li><a href="../chat-resources.html">Chat Resources</a></li>
-                        </ul>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../contribute.html">Contribute Overview</a></li>
-                            <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                        </ul>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
+                      </ul>
                     </li>
-                    <li><a href="../faq.html">FAQ</a></li>
-                    <li><a href="../index.html#about">About</a></li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -284,11 +316,11 @@ chmod u+x cloudgoat.py</code></pre><p>Configure CloudGoat with your default AWS 
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -297,17 +329,24 @@ chmod u+x cloudgoat.py</code></pre><p>Configure CloudGoat with your default AWS 
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/portfolio/cnapp-comparison.html
+++ b/portfolio/cnapp-comparison.html
@@ -32,10 +32,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -89,55 +89,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li class="has-dropdown">
-                        <button class="dropdown-toggle active" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
                             <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                            <li><a href="../learning-path.html">Learning Path</a></li>
-                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                            <li><a href="../cloud-security-careers.html">Careers</a></li>
-                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
                             <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
                             <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                            <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ctfs.html">CTFs</a></li>
-                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                            <li><a href="../github-actions.html">GitHub Actions</a></li>
                             <li><a href="../glossary.html">Glossary</a></li>
-                        </ul>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html" aria-current="page">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Defend <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../news.html">News</a></li>
-                            <li><a href="../threat-research.html">Threat Research</a></li>
-                            <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
-                        </ul>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
+                        <li><a href="../threat-research.html">Threat Research</a></li>
+                        <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
+                        <li><a href="../cloud-soc.html">Cloud SOC</a></li>
+                        <li><a href="../ctfs.html">CTFs</a></li>
+                      </ul>
                     </li>
-                    <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../sessions.html">Zoom Sessions</a></li>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
                             <li><a href="../community.html">Community &amp; Signal</a></li>
                             <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
                             <li><a href="../meetings.html">Meeting Recaps</a></li>
                             <li><a href="../presentations.html">Presentations</a></li>
                             <li><a href="../chat-resources.html">Chat Resources</a></li>
-                        </ul>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../contribute.html">Contribute Overview</a></li>
-                            <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                        </ul>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
+                      </ul>
                     </li>
-                    <li><a href="../faq.html">FAQ</a></li>
-                    <li><a href="../index.html#about">About</a></li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -277,11 +309,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -290,17 +322,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/portfolio/cnapp-comparison.html
+++ b/portfolio/cnapp-comparison.html
@@ -164,7 +164,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/portfolio/detection-lab.html
+++ b/portfolio/detection-lab.html
@@ -164,7 +164,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/portfolio/detection-lab.html
+++ b/portfolio/detection-lab.html
@@ -32,10 +32,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -89,55 +89,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li class="has-dropdown">
-                        <button class="dropdown-toggle active" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
                             <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                            <li><a href="../learning-path.html">Learning Path</a></li>
-                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                            <li><a href="../cloud-security-careers.html">Careers</a></li>
-                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
                             <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
                             <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                            <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ctfs.html">CTFs</a></li>
-                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                            <li><a href="../github-actions.html">GitHub Actions</a></li>
                             <li><a href="../glossary.html">Glossary</a></li>
-                        </ul>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html" aria-current="page">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Defend <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../news.html">News</a></li>
-                            <li><a href="../threat-research.html">Threat Research</a></li>
-                            <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
-                        </ul>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
+                        <li><a href="../threat-research.html">Threat Research</a></li>
+                        <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
+                        <li><a href="../cloud-soc.html">Cloud SOC</a></li>
+                        <li><a href="../ctfs.html">CTFs</a></li>
+                      </ul>
                     </li>
-                    <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../sessions.html">Zoom Sessions</a></li>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
                             <li><a href="../community.html">Community &amp; Signal</a></li>
                             <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
                             <li><a href="../meetings.html">Meeting Recaps</a></li>
                             <li><a href="../presentations.html">Presentations</a></li>
                             <li><a href="../chat-resources.html">Chat Resources</a></li>
-                        </ul>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../contribute.html">Contribute Overview</a></li>
-                            <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                        </ul>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
+                      </ul>
                     </li>
-                    <li><a href="../faq.html">FAQ</a></li>
-                    <li><a href="../index.html#about">About</a></li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -277,11 +309,11 @@ stratus detonate aws.credential-access.ec2-get-password-data</code></pre>
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -290,17 +322,24 @@ stratus detonate aws.credential-access.ec2-get-password-data</code></pre>
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/portfolio/open-source-contribution.html
+++ b/portfolio/open-source-contribution.html
@@ -32,10 +32,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -89,55 +89,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li class="has-dropdown">
-                        <button class="dropdown-toggle active" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
                             <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                            <li><a href="../learning-path.html">Learning Path</a></li>
-                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                            <li><a href="../cloud-security-careers.html">Careers</a></li>
-                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
                             <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
                             <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                            <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ctfs.html">CTFs</a></li>
-                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                            <li><a href="../github-actions.html">GitHub Actions</a></li>
                             <li><a href="../glossary.html">Glossary</a></li>
-                        </ul>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html" aria-current="page">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Defend <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../news.html">News</a></li>
-                            <li><a href="../threat-research.html">Threat Research</a></li>
-                            <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
-                        </ul>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
+                        <li><a href="../threat-research.html">Threat Research</a></li>
+                        <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
+                        <li><a href="../cloud-soc.html">Cloud SOC</a></li>
+                        <li><a href="../ctfs.html">CTFs</a></li>
+                      </ul>
                     </li>
-                    <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../sessions.html">Zoom Sessions</a></li>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
                             <li><a href="../community.html">Community &amp; Signal</a></li>
                             <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
                             <li><a href="../meetings.html">Meeting Recaps</a></li>
                             <li><a href="../presentations.html">Presentations</a></li>
                             <li><a href="../chat-resources.html">Chat Resources</a></li>
-                        </ul>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../contribute.html">Contribute Overview</a></li>
-                            <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                        </ul>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
+                      </ul>
                     </li>
-                    <li><a href="../faq.html">FAQ</a></li>
-                    <li><a href="../index.html#about">About</a></li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -278,11 +310,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -291,17 +323,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/portfolio/open-source-contribution.html
+++ b/portfolio/open-source-contribution.html
@@ -164,7 +164,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/portfolio/prowler-audit.html
+++ b/portfolio/prowler-audit.html
@@ -32,10 +32,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -89,55 +89,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li class="has-dropdown">
-                        <button class="dropdown-toggle active" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
                             <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                            <li><a href="../learning-path.html">Learning Path</a></li>
-                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                            <li><a href="../cloud-security-careers.html">Careers</a></li>
-                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
                             <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
                             <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                            <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ctfs.html">CTFs</a></li>
-                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                            <li><a href="../github-actions.html">GitHub Actions</a></li>
                             <li><a href="../glossary.html">Glossary</a></li>
-                        </ul>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html" aria-current="page">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Defend <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../news.html">News</a></li>
-                            <li><a href="../threat-research.html">Threat Research</a></li>
-                            <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
-                        </ul>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
+                        <li><a href="../threat-research.html">Threat Research</a></li>
+                        <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
+                        <li><a href="../cloud-soc.html">Cloud SOC</a></li>
+                        <li><a href="../ctfs.html">CTFs</a></li>
+                      </ul>
                     </li>
-                    <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../sessions.html">Zoom Sessions</a></li>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
                             <li><a href="../community.html">Community &amp; Signal</a></li>
                             <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
                             <li><a href="../meetings.html">Meeting Recaps</a></li>
                             <li><a href="../presentations.html">Presentations</a></li>
                             <li><a href="../chat-resources.html">Chat Resources</a></li>
-                        </ul>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../contribute.html">Contribute Overview</a></li>
-                            <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                        </ul>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
+                      </ul>
                     </li>
-                    <li><a href="../faq.html">FAQ</a></li>
-                    <li><a href="../index.html#about">About</a></li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -276,11 +308,11 @@ prowler --version</code></pre>
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -289,17 +321,24 @@ prowler --version</code></pre>
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/portfolio/prowler-audit.html
+++ b/portfolio/prowler-audit.html
@@ -164,7 +164,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/portfolio/recreate-capital-one.html
+++ b/portfolio/recreate-capital-one.html
@@ -32,10 +32,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -89,55 +89,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li class="has-dropdown">
-                        <button class="dropdown-toggle active" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
                             <li><a href="../what-is-cloud-security.html">What is Cloud Security?</a></li>
-                            <li><a href="../learning-path.html">Learning Path</a></li>
-                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
-                            <li><a href="../cloud-security-careers.html">Careers</a></li>
-                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
-                            <li><a href="../cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
-                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
                             <li><a href="../shared-responsibility-model.html">Shared Responsibility</a></li>
                             <li><a href="../cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                            <li><a href="../resources.html">Resources</a></li>
-                            <li><a href="../ctfs.html">CTFs</a></li>
-                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
-                            <li><a href="../github-actions.html">GitHub Actions</a></li>
                             <li><a href="../glossary.html">Glossary</a></li>
-                        </ul>
+                            <li><a href="../faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="../cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="../containers.html">Containers</a></li>
+                            <li><a href="../kubernetes.html">Kubernetes</a></li>
+                            <li><a href="../serverless.html">Serverless</a></li>
+                            <li><a href="../ci-cd.html">CI/CD</a></li>
+                            <li><a href="../landing-zones.html">Landing Zones</a></li>
+                            <li><a href="../grc.html">GRC</a></li>
+                            <li><a href="../ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="../learning-path.html">Learning Path</a></li>
+                            <li><a href="../cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="../cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="../cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="../cloud-security-portfolio-projects.html" aria-current="page">Portfolio Projects</a></li>
+                            <li><a href="../cloud-security-careers.html">Careers</a></li>
+                            <li><a href="../cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="../resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Defend <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../news.html">News</a></li>
-                            <li><a href="../threat-research.html">Threat Research</a></li>
-                            <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
-                        </ul>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="../news.html">News</a></li>
+                        <li><a href="../threat-research.html">Threat Research</a></li>
+                        <li><a href="../breach-timeline.html">Breach Kill Chains</a></li>
+                        <li><a href="../cloud-soc.html">Cloud SOC</a></li>
+                        <li><a href="../ctfs.html">CTFs</a></li>
+                      </ul>
                     </li>
-                    <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../sessions.html">Zoom Sessions</a></li>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="../sessions.html">Friday Zoom Sessions</a></li>
                             <li><a href="../community.html">Community &amp; Signal</a></li>
                             <li><a href="../conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
                             <li><a href="../meetings.html">Meeting Recaps</a></li>
                             <li><a href="../presentations.html">Presentations</a></li>
                             <li><a href="../chat-resources.html">Chat Resources</a></li>
-                        </ul>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
-                        <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                        <ul class="dropdown-menu">
-                            <li><a href="../contribute.html">Contribute Overview</a></li>
-                            <li><a href="../contribute-resources.html">Add a Resource</a></li>
-                        </ul>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="../contribute.html">Contribute</a></li>
+                        <li><a href="../contribute-resources.html">Add a Resource</a></li>
+                      </ul>
                     </li>
-                    <li><a href="../faq.html">FAQ</a></li>
-                    <li><a href="../index.html#about">About</a></li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -277,11 +309,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="../learning-path.html">Learning Path</a></li>
+          <li><a href="../resources.html">Resources</a></li>
+          <li><a href="../news.html">News</a></li>
+          <li><a href="../sessions.html">Zoom Sessions</a></li>
+          <li><a href="../meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -290,17 +322,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="../rss.html">RSS Feed</a></li>
+          <li><a href="../contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="../github-actions.html">GitHub Actions</a></li>
+          <li><a href="../cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="../privacy.html">Privacy</a></li>
+        <li><a href="../code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="../security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/portfolio/recreate-capital-one.html
+++ b/portfolio/recreate-capital-one.html
@@ -164,7 +164,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="../about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="../contribute.html">Contribute</a></li>
                         <li><a href="../contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/presentations.html
+++ b/presentations.html
@@ -41,10 +41,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <!-- Structured Data -->
     <script type="application/ld+json">
@@ -320,73 +320,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html" aria-current="page">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html" aria-current="page">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -659,11 +673,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -672,17 +686,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/presentations.html
+++ b/presentations.html
@@ -395,7 +395,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/privacy.html
+++ b/privacy.html
@@ -35,10 +35,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
   <noscript><style>.js-enabled header nav{display:block !important}</style></noscript>
 </head>
 
@@ -57,73 +57,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -250,11 +264,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -263,17 +277,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/privacy.html
+++ b/privacy.html
@@ -132,7 +132,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/resources.html
+++ b/resources.html
@@ -41,11 +41,11 @@
     <link rel="dns-prefetch" href="https://github.com">
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <!-- Structured Data for SEO -->
     <script type="application/ld+json">
@@ -207,73 +207,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html" aria-current="page">Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html" class="active" aria-current="page">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -3272,11 +3286,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -3285,17 +3299,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/resources.html
+++ b/resources.html
@@ -282,7 +282,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/rss.html
+++ b/rss.html
@@ -163,7 +163,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/rss.html
+++ b/rss.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -88,73 +88,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">&#127769;</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -354,11 +368,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -367,17 +381,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/security-policy.html
+++ b/security-policy.html
@@ -138,7 +138,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/security-policy.html
+++ b/security-policy.html
@@ -40,11 +40,11 @@
     <link rel="dns-prefetch" href="https://github.com">
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
   <noscript><style>.js-enabled header nav{display:block !important}</style></noscript>
 </head>
 
@@ -63,73 +63,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -283,11 +297,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -296,17 +310,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/serverless.html
+++ b/serverless.html
@@ -34,10 +34,10 @@
     <link rel="preconnect" href="https://github.com" crossorigin>
     <link rel="dns-prefetch" href="https://github.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -133,73 +133,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html" aria-current="page">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html" aria-current="page">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -828,11 +842,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -841,17 +855,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/serverless.html
+++ b/serverless.html
@@ -208,7 +208,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/sessions.html
+++ b/sessions.html
@@ -40,10 +40,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <!-- Structured Data -->
     <script type="application/ld+json">
@@ -84,73 +84,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html" aria-current="page">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html" aria-current="page">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -297,11 +311,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -310,17 +324,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/sessions.html
+++ b/sessions.html
@@ -159,7 +159,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/shared-responsibility-model.html
+++ b/shared-responsibility-model.html
@@ -215,7 +215,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/shared-responsibility-model.html
+++ b/shared-responsibility-model.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -140,73 +140,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html" aria-current="page">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html" aria-current="page">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -679,11 +693,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -692,17 +706,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/style.css
+++ b/style.css
@@ -3488,6 +3488,203 @@ footer {
     }
 }
 
+/* =========================================================================
+   MEGA-MENU + NAV CTA  (added in 2026-05 nav redesign)
+   ========================================================================= */
+
+/* Mega-menu container — wider than the standard dropdown, multi-column.
+   The .dropdown-menu base styles still apply (positioning, hover reveal,
+   etc.); these rules override the width/layout so it can hold columns. */
+.has-mega > .dropdown-menu.mega-menu {
+    min-width: 580px;
+    max-width: 92vw;
+    padding: 1rem 1.25rem 1.1rem;
+    /* Center under the toggle so the menu stays visually balanced even
+       when the toggle is far left or far right in the nav. */
+    left: 50%;
+    transform: translateX(-50%) translateY(-4px);
+    display: grid;
+    gap: 1.5rem;
+}
+
+.has-mega:hover > .dropdown-menu.mega-menu,
+.has-mega:focus-within > .dropdown-menu.mega-menu,
+.has-mega.open > .dropdown-menu.mega-menu {
+    transform: translateX(-50%) translateY(0);
+}
+
+.has-mega > .dropdown-menu.mega-3col {
+    grid-template-columns: repeat(3, minmax(150px, 1fr));
+    min-width: 680px;
+}
+
+.has-mega > .dropdown-menu.mega-2col {
+    grid-template-columns: repeat(2, minmax(150px, 1fr));
+    min-width: 440px;
+}
+
+.mega-col > ul {
+    /* Override the global `nav ul { display: flex; gap: 2rem }` rule so
+       links inside a mega-menu column stack vertically. */
+    display: block;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    gap: 0;
+    align-items: stretch;
+}
+
+.mega-col > ul > li {
+    display: block;
+}
+
+.mega-heading {
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255, 255, 255, 0.65);
+    margin: 0 0 0.4rem;
+    padding: 0 0.5rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    padding-bottom: 0.4rem;
+}
+
+.mega-menu .mega-col a {
+    display: block;
+    padding: 0.4rem 0.5rem;
+    border-radius: 4px;
+    white-space: normal;
+    line-height: 1.25;
+}
+
+.mega-menu .mega-col a:hover,
+.mega-menu .mega-col a:focus {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+.mega-menu .mega-col a[aria-current="page"] {
+    background-color: rgba(255, 255, 255, 0.18);
+}
+
+/* Persistent nav CTA — promotes Friday Zoom out of a dropdown.
+   Designed to stand out without fighting the logo or hero CTA. */
+.nav-cta-item {
+    margin-left: 0.5rem;
+}
+
+.nav-cta {
+    display: inline-block;
+    background-color: var(--accent-color, #f59e0b);
+    color: #1a202c !important;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background-color 0.15s, transform 0.12s;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.18);
+}
+
+.nav-cta:hover,
+.nav-cta:focus {
+    background-color: #fbbf24;
+    transform: translateY(-1px);
+    opacity: 1 !important;
+}
+
+/* Make sure the global nav active-pill style doesn't accidentally wrap the
+   CTA, and that aria-current pill doesn't apply to the CTA button. */
+.nav-cta-item .nav-cta:focus {
+    outline: 3px solid rgba(245, 158, 11, 0.5);
+    outline-offset: 2px;
+}
+
+/* Mobile: mega-menu flattens to the accordion pattern already used for
+   standard dropdowns. We reset the desktop grid + centering so it stacks
+   like a regular dropdown, but keep the section headings visible to
+   preserve the grouped structure. */
+@media (max-width: 768px) {
+    .has-mega > .dropdown-menu.mega-menu {
+        display: block;
+        min-width: 0;
+        max-width: none;
+        padding: 0;
+        left: 0;
+        transform: none;
+    }
+
+    .has-mega.open > .dropdown-menu.mega-menu {
+        transform: none;
+        /* Mega-menus hold ~20 items + 3 section headings — well over the
+           standard 800px ceiling. Give them enough room to render fully
+           inside the mobile accordion without scroll-clipping. */
+        max-height: 1500px;
+    }
+
+    .has-mega:hover > .dropdown-menu.mega-menu,
+    .has-mega:focus-within > .dropdown-menu.mega-menu {
+        transform: none;
+    }
+
+    .mega-col {
+        padding: 0.4rem 0 0.6rem;
+    }
+
+    .mega-heading {
+        font-size: 0.7rem;
+        margin: 0;
+        padding: 0.7rem 1.5rem 0.3rem;
+        border-bottom: none;
+        color: rgba(255, 255, 255, 0.55);
+    }
+
+    .mega-menu .mega-col a {
+        /* Match the indented chevron sub-item shape used by standard
+           dropdowns on mobile (defined ~line 3441). */
+        padding: 0.55rem 1rem 0.55rem 2.5rem;
+        font-size: 0.85rem;
+        border-radius: 0;
+        border-top: 1px solid rgba(255, 255, 255, 0.05);
+        position: relative;
+        opacity: 0.92;
+    }
+
+    .mega-menu .mega-col a::before {
+        content: "›";
+        position: absolute;
+        left: 1.25rem;
+        top: 50%;
+        transform: translateY(-50%);
+        opacity: 0.5;
+        font-size: 0.95rem;
+        line-height: 1;
+        pointer-events: none;
+    }
+
+    /* CTA on mobile: full-width button at the bottom of the accordion. */
+    .nav-cta-item {
+        margin: 0.75rem 1rem 0.5rem;
+    }
+
+    .nav-cta {
+        display: block;
+        text-align: center;
+        padding: 0.75rem 1rem;
+    }
+}
+
+/* Dark mode: mega-menu inherits the dropdown-menu dark styles since it
+   uses the same `.dropdown-menu` class, but the section headings need an
+   explicit color so they remain legible. */
+[data-theme="dark"] .mega-heading {
+    color: rgba(255, 255, 255, 0.7);
+    border-bottom-color: rgba(255, 255, 255, 0.1);
+}
+
+[data-theme="dark"] .nav-cta {
+    color: #1a202c !important;
+}
+
 /* end of stylesheet - v2 */
 /* =========================================================================
    MEETINGS.HTML INDEX (after split into per-meeting pages)

--- a/threat-research.html
+++ b/threat-research.html
@@ -177,7 +177,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/threat-research.html
+++ b/threat-research.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <!-- Structured Data -->
     <script type="application/ld+json">
@@ -102,73 +102,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html" aria-current="page">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -1275,11 +1289,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -1288,17 +1302,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>

--- a/tools/redesign_nav.py
+++ b/tools/redesign_nav.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Redesign the site nav and footer across all HTML pages.
+
+New IA:
+  - Learn (mega-menu, 3 cols: Foundations / Topics / Career & Growth)
+  - Resources (direct link)
+  - Threat Intel (dropdown; News promoted here)
+  - Community (mega-menu, 2 cols: Live / Archive)
+  - About (dropdown; absorbs Contribute)
+  - Join Friday Zoom (CTA button)
+
+Footer adds a 'Developer Docs' column for github-actions + cloud-deployment.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# basename -> (top_menu_label, link_text) — used to set aria-current + active
+ACTIVE_MAP: dict[str, tuple[str, str]] = {
+    # Threat Intel
+    "news.html": ("Threat Intel", "News"),
+    "threat-research.html": ("Threat Intel", "Threat Research"),
+    "breach-timeline.html": ("Threat Intel", "Breach Kill Chains"),
+    "cloud-soc.html": ("Threat Intel", "Cloud SOC"),
+    "ctfs.html": ("Threat Intel", "CTFs"),
+    # Learn > Foundations
+    "what-is-cloud-security.html": ("Learn", "What is Cloud Security?"),
+    "shared-responsibility-model.html": ("Learn", "Shared Responsibility"),
+    "cspm-vs-cnapp.html": ("Learn", "CSPM vs CNAPP"),
+    "glossary.html": ("Learn", "Glossary"),
+    "faq.html": ("Learn", "FAQ"),
+    # Learn > Topics
+    "cloud-security-best-practices.html": ("Learn", "Best Practices"),
+    "containers.html": ("Learn", "Containers"),
+    "kubernetes.html": ("Learn", "Kubernetes"),
+    "serverless.html": ("Learn", "Serverless"),
+    "ci-cd.html": ("Learn", "CI/CD"),
+    "landing-zones.html": ("Learn", "Landing Zones"),
+    "grc.html": ("Learn", "GRC"),
+    "ai-learning.html": ("Learn", "AI Learning"),
+    # Learn > Career & Growth
+    "learning-path.html": ("Learn", "Learning Path"),
+    "cloud-security-certifications.html": ("Learn", "Certifications"),
+    "cloud-security-degree-programs.html": ("Learn", "Degree Programs"),
+    "cloud-security-home-lab.html": ("Learn", "Home Lab"),
+    "cloud-security-portfolio-projects.html": ("Learn", "Portfolio Projects"),
+    "cloud-security-careers.html": ("Learn", "Careers"),
+    "cloud-security-reading-list.html": ("Learn", "Reading List"),
+    # Resources
+    "resources.html": ("__TOP__", "Resources"),
+    # Community
+    "sessions.html": ("Community", "Friday Zoom Sessions"),
+    "community.html": ("Community", "Community &amp; Signal"),
+    "conferences.html": ("Community", "Conferences"),
+    "meetings.html": ("Community", "Meeting Recaps"),
+    "presentations.html": ("Community", "Presentations"),
+    "chat-resources.html": ("Community", "Chat Resources"),
+    # About
+    "about-shawn-nunley.html": ("About", "About Shawn"),
+    "contribute.html": ("About", "Contribute"),
+    "contribute-resources.html": ("About", "Add a Resource"),
+}
+
+# Subdir basename heuristics: any meeting page → Meeting Recaps; etc.
+SUBDIR_ACTIVE: dict[str, tuple[str, str]] = {
+    "meetings": ("Community", "Meeting Recaps"),
+    "breaches": ("Threat Intel", "Breach Kill Chains"),
+    "portfolio": ("Learn", "Portfolio Projects"),
+}
+
+
+def nav_html(prefix: str, active_top: str | None, active_link: str | None) -> str:
+    """Build the new <nav>...</nav> markup.
+
+    prefix: '' for root pages, '../' for subdir pages.
+    active_top: top-level menu to mark active (or None / '__TOP__' for direct links).
+    active_link: the leaf link text to mark with aria-current.
+    """
+    P = prefix
+
+    def is_top(label: str) -> bool:
+        return active_top == label
+
+    def is_link(text: str) -> bool:
+        return active_link == text
+
+    def cur(text: str) -> str:
+        return ' aria-current="page"' if is_link(text) else ''
+
+    def toggle_attrs(label: str) -> str:
+        active = is_top(label)
+        cls = "dropdown-toggle active" if active else "dropdown-toggle"
+        expanded = "true" if active else "false"
+        return f'class="{cls}" aria-expanded="{expanded}" aria-haspopup="true"'
+
+    resources_attrs = ' aria-current="page"' if active_top == "__TOP__" and active_link == "Resources" else ''
+    resources_cls = ' class="active"' if resources_attrs else ''
+
+    return f'''<nav>
+                <ul>
+                    <li class="has-dropdown has-mega">
+                      <button {toggle_attrs("Learn")}>Learn <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="{P}what-is-cloud-security.html"{cur("What is Cloud Security?")}>What is Cloud Security?</a></li>
+                            <li><a href="{P}shared-responsibility-model.html"{cur("Shared Responsibility")}>Shared Responsibility</a></li>
+                            <li><a href="{P}cspm-vs-cnapp.html"{cur("CSPM vs CNAPP")}>CSPM vs CNAPP</a></li>
+                            <li><a href="{P}glossary.html"{cur("Glossary")}>Glossary</a></li>
+                            <li><a href="{P}faq.html"{cur("FAQ")}>FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="{P}cloud-security-best-practices.html"{cur("Best Practices")}>Best Practices</a></li>
+                            <li><a href="{P}containers.html"{cur("Containers")}>Containers</a></li>
+                            <li><a href="{P}kubernetes.html"{cur("Kubernetes")}>Kubernetes</a></li>
+                            <li><a href="{P}serverless.html"{cur("Serverless")}>Serverless</a></li>
+                            <li><a href="{P}ci-cd.html"{cur("CI/CD")}>CI/CD</a></li>
+                            <li><a href="{P}landing-zones.html"{cur("Landing Zones")}>Landing Zones</a></li>
+                            <li><a href="{P}grc.html"{cur("GRC")}>GRC</a></li>
+                            <li><a href="{P}ai-learning.html"{cur("AI Learning")}>AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="{P}learning-path.html"{cur("Learning Path")}>Learning Path</a></li>
+                            <li><a href="{P}cloud-security-certifications.html"{cur("Certifications")}>Certifications</a></li>
+                            <li><a href="{P}cloud-security-degree-programs.html"{cur("Degree Programs")}>Degree Programs</a></li>
+                            <li><a href="{P}cloud-security-home-lab.html"{cur("Home Lab")}>Home Lab</a></li>
+                            <li><a href="{P}cloud-security-portfolio-projects.html"{cur("Portfolio Projects")}>Portfolio Projects</a></li>
+                            <li><a href="{P}cloud-security-careers.html"{cur("Careers")}>Careers</a></li>
+                            <li><a href="{P}cloud-security-reading-list.html"{cur("Reading List")}>Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
+                    <li><a href="{P}resources.html"{resources_cls}{resources_attrs}>Resources</a></li>
+                    <li class="has-dropdown">
+                      <button {toggle_attrs("Threat Intel")}>Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="{P}news.html"{cur("News")}>News</a></li>
+                        <li><a href="{P}threat-research.html"{cur("Threat Research")}>Threat Research</a></li>
+                        <li><a href="{P}breach-timeline.html"{cur("Breach Kill Chains")}>Breach Kill Chains</a></li>
+                        <li><a href="{P}cloud-soc.html"{cur("Cloud SOC")}>Cloud SOC</a></li>
+                        <li><a href="{P}ctfs.html"{cur("CTFs")}>CTFs</a></li>
+                      </ul>
+                    </li>
+                    <li class="has-dropdown has-mega">
+                      <button {toggle_attrs("Community")}>Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="{P}sessions.html"{cur("Friday Zoom Sessions")}>Friday Zoom Sessions</a></li>
+                            <li><a href="{P}community.html"{cur("Community &amp; Signal")}>Community &amp; Signal</a></li>
+                            <li><a href="{P}conferences.html"{cur("Conferences")}>Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="{P}meetings.html"{cur("Meeting Recaps")}>Meeting Recaps</a></li>
+                            <li><a href="{P}presentations.html"{cur("Presentations")}>Presentations</a></li>
+                            <li><a href="{P}chat-resources.html"{cur("Chat Resources")}>Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
+                    <li class="has-dropdown">
+                      <button {toggle_attrs("About")}>About <span class="caret" aria-hidden="true">▾</span></button>
+                      <ul class="dropdown-menu">
+                        <li><a href="{P}about-shawn-nunley.html"{cur("About Shawn")}>About Shawn</a></li>
+                        <li><a href="{P}contribute.html"{cur("Contribute")}>Contribute</a></li>
+                        <li><a href="{P}contribute-resources.html"{cur("Add a Resource")}>Add a Resource</a></li>
+                      </ul>
+                    </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
+                </ul>
+            </nav>'''
+
+
+def footer_html(prefix: str) -> str:
+    P = prefix
+    return f'''<footer>
+    <div class="footer-content">
+      <div class="footer-section footer-about">
+        <h3>CSOH</h3>
+        <p>A vendor-neutral community for cloud security professionals. Weekly Zoom sessions and curated resources.</p>
+      </div>
+      <div class="footer-section">
+        <h3>Explore</h3>
+        <ul>
+          <li><a href="{P}learning-path.html">Learning Path</a></li>
+          <li><a href="{P}resources.html">Resources</a></li>
+          <li><a href="{P}news.html">News</a></li>
+          <li><a href="{P}sessions.html">Zoom Sessions</a></li>
+          <li><a href="{P}meetings.html">Meeting Recaps</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Connect</h3>
+        <ul>
+          <li><a href="mailto:admin@csoh.org">Contact</a></li>
+          <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
+          <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+          <li><a href="{P}rss.html">RSS Feed</a></li>
+          <li><a href="{P}contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="{P}github-actions.html">GitHub Actions</a></li>
+          <li><a href="{P}cloud-deployment.html">Deploy to GCP</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <p>&copy; 2023-2026 Cloud Security Office Hours</p>
+      <ul class="footer-legal">
+        <li><a href="{P}privacy.html">Privacy</a></li>
+        <li><a href="{P}code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="{P}security-policy.html">Security</a></li>
+      </ul>
+    </div>
+  </footer>'''
+
+
+NAV_RE = re.compile(r'<nav>\s*<ul>.*?</ul>\s*</nav>', re.DOTALL)
+FOOTER_RE = re.compile(r'<footer>.*?</footer>', re.DOTALL)
+
+
+def update_file(path: Path) -> bool:
+    """Return True if file was modified."""
+    text = path.read_text(encoding='utf-8')
+
+    # Determine prefix
+    rel = path.relative_to(ROOT)
+    depth = len(rel.parts) - 1
+    prefix = '../' * depth
+
+    # Determine active state
+    basename = path.name
+    if depth == 0:
+        active_top, active_link = (None, None)
+        if basename in ACTIVE_MAP:
+            active_top, active_link = ACTIVE_MAP[basename]
+    else:
+        subdir = rel.parts[0]
+        active_top, active_link = SUBDIR_ACTIVE.get(subdir, (None, None))
+
+    new_nav = nav_html(prefix, active_top, active_link)
+    new_footer = footer_html(prefix)
+
+    new_text = text
+    nav_match = NAV_RE.search(new_text)
+    if nav_match:
+        new_text = new_text[:nav_match.start()] + new_nav + new_text[nav_match.end():]
+    footer_match = FOOTER_RE.search(new_text)
+    if footer_match:
+        new_text = new_text[:footer_match.start()] + new_footer + new_text[footer_match.end():]
+
+    if new_text != text:
+        path.write_text(new_text, encoding='utf-8')
+        return True
+    return False
+
+
+def main() -> int:
+    files: list[Path] = []
+    files.extend(sorted(ROOT.glob('*.html')))
+    files.extend(sorted(ROOT.glob('meetings/*.html')))
+    files.extend(sorted(ROOT.glob('breaches/*.html')))
+    files.extend(sorted(ROOT.glob('portfolio/*.html')))
+
+    # Skip files we don't want to touch
+    skip = {'google66d489593949bd4c.html'}
+
+    changed = 0
+    skipped = 0
+    for f in files:
+        if f.name in skip:
+            skipped += 1
+            continue
+        if not NAV_RE.search(f.read_text(encoding='utf-8')):
+            print(f"  skip (no nav): {f.relative_to(ROOT)}")
+            skipped += 1
+            continue
+        if update_file(f):
+            changed += 1
+        else:
+            skipped += 1
+    print(f"Updated {changed} files, skipped {skipped}.")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/redesign_nav.py
+++ b/tools/redesign_nav.py
@@ -60,7 +60,6 @@ ACTIVE_MAP: dict[str, tuple[str, str]] = {
     "presentations.html": ("Community", "Presentations"),
     "chat-resources.html": ("Community", "Chat Resources"),
     # About
-    "about-shawn-nunley.html": ("About", "About Shawn"),
     "contribute.html": ("About", "Contribute"),
     "contribute-resources.html": ("About", "Add a Resource"),
 }
@@ -177,7 +176,6 @@ def nav_html(prefix: str, active_top: str | None, active_link: str | None) -> st
                     <li class="has-dropdown">
                       <button {toggle_attrs("About")}>About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="{P}about-shawn-nunley.html"{cur("About Shawn")}>About Shawn</a></li>
                         <li><a href="{P}contribute.html"{cur("Contribute")}>Contribute</a></li>
                         <li><a href="{P}contribute-resources.html"{cur("Add a Resource")}>Add a Resource</a></li>
                       </ul>

--- a/what-is-cloud-security.html
+++ b/what-is-cloud-security.html
@@ -231,7 +231,6 @@
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
                         <li><a href="contribute.html">Contribute</a></li>
                         <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>

--- a/what-is-cloud-security.html
+++ b/what-is-cloud-security.html
@@ -39,10 +39,10 @@
     <link rel="dns-prefetch" href="https://www.paypal.com/us/home">
     <link rel="dns-prefetch" href="https://img.youtube.com">
 
-    <link rel="preload" href="/style.css?v=0d8fc81d" as="style"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
-    <link rel="stylesheet" href="/style.css?v=0d8fc81d"
-        integrity="sha384-T2RglkzlwLN3tjrobi8W8V4aTwvuaVZzMON0R16FuXpbTuQimufZPvR4j4UupkNE">
+    <link rel="preload" href="/style.css?v=81490698" as="style"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
+    <link rel="stylesheet" href="/style.css?v=81490698"
+        integrity="sha384-ULrcmaXRxf+GLip0yWUoKHAupnS46Bb35vCTSIyZGvjgvwwGo7ffSVFSyItMSda8">
 
     <script type="application/ld+json">
     {
@@ -156,73 +156,87 @@
             <button class="theme-toggle" aria-label="Switch to dark mode">🌙</button>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="news.html">News</a></li>
-                    <li class="has-dropdown">
+                    <li class="has-dropdown has-mega">
                       <button class="dropdown-toggle active" aria-expanded="true" aria-haspopup="true">Learn <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="what-is-cloud-security.html" aria-current="page">What is Cloud Security?</a></li>
-                        <li><a href="learning-path.html">Learning Path</a></li>
-                        <li><a href="ai-learning.html">AI Learning</a></li>
-                        <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
-                        <li><a href="cloud-security-careers.html">Careers</a></li>
-                        <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
-                        <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
-                        <li><a href="cloud-security-certifications.html">Certifications</a></li>
-                        <li><a href="resources.html">Resources</a></li>
-                      </ul>
+                      <div class="dropdown-menu mega-menu mega-3col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Foundations</h4>
+                          <ul>
+                            <li><a href="what-is-cloud-security.html" aria-current="page">What is Cloud Security?</a></li>
+                            <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
+                            <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
+                            <li><a href="glossary.html">Glossary</a></li>
+                            <li><a href="faq.html">FAQ</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Topics</h4>
+                          <ul>
+                            <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
+                            <li><a href="containers.html">Containers</a></li>
+                            <li><a href="kubernetes.html">Kubernetes</a></li>
+                            <li><a href="serverless.html">Serverless</a></li>
+                            <li><a href="ci-cd.html">CI/CD</a></li>
+                            <li><a href="landing-zones.html">Landing Zones</a></li>
+                            <li><a href="grc.html">GRC</a></li>
+                            <li><a href="ai-learning.html">AI Learning</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Career &amp; Growth</h4>
+                          <ul>
+                            <li><a href="learning-path.html">Learning Path</a></li>
+                            <li><a href="cloud-security-certifications.html">Certifications</a></li>
+                            <li><a href="cloud-security-degree-programs.html">Degree Programs</a></li>
+                            <li><a href="cloud-security-home-lab.html">Home Lab</a></li>
+                            <li><a href="cloud-security-portfolio-projects.html">Portfolio Projects</a></li>
+                            <li><a href="cloud-security-careers.html">Careers</a></li>
+                            <li><a href="cloud-security-reading-list.html">Reading List</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
+                    <li><a href="resources.html">Resources</a></li>
                     <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Topics <span class="caret" aria-hidden="true">▾</span></button>
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Threat Intel <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="cloud-security-best-practices.html">Best Practices</a></li>
-                        <li><a href="shared-responsibility-model.html">Shared Responsibility</a></li>
-                        <li><a href="cspm-vs-cnapp.html">CSPM vs CNAPP</a></li>
-                        <li><a href="landing-zones.html">Landing Zones</a></li>
-                        <li><a href="containers.html">Containers</a></li>
-                        <li><a href="kubernetes.html">Kubernetes</a></li>
-                        <li><a href="serverless.html">Serverless</a></li>
-                        <li><a href="ci-cd.html">CI/CD</a></li>
-                        <li><a href="grc.html">GRC</a></li>
-                        <li><a href="cloud-security-reading-list.html">Reading List</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Detection and Response <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
+                        <li><a href="news.html">News</a></li>
                         <li><a href="threat-research.html">Threat Research</a></li>
                         <li><a href="breach-timeline.html">Breach Kill Chains</a></li>
                         <li><a href="cloud-soc.html">Cloud SOC</a></li>
                         <li><a href="ctfs.html">CTFs</a></li>
                       </ul>
                     </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Attend <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="sessions.html">Zoom Sessions</a></li>
-                        <li><a href="community.html">Community &amp; Signal</a></li>
-                        <li><a href="conferences.html">Conferences</a></li>
-                        <li><a href="meetings.html">Meeting Recaps</a></li>
-                        <li><a href="presentations.html">Presentations</a></li>
-                        <li><a href="chat-resources.html">Chat Resources</a></li>
-                      </ul>
-                    </li>
-                    <li class="has-dropdown">
-                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Contribute <span class="caret" aria-hidden="true">▾</span></button>
-                      <ul class="dropdown-menu">
-                        <li><a href="contribute.html">Contribute Overview</a></li>
-                        <li><a href="contribute-resources.html">Add a Resource</a></li>
-                      </ul>
+                    <li class="has-dropdown has-mega">
+                      <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">Community <span class="caret" aria-hidden="true">▾</span></button>
+                      <div class="dropdown-menu mega-menu mega-2col">
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Live</h4>
+                          <ul>
+                            <li><a href="sessions.html">Friday Zoom Sessions</a></li>
+                            <li><a href="community.html">Community &amp; Signal</a></li>
+                            <li><a href="conferences.html">Conferences</a></li>
+                          </ul>
+                        </div>
+                        <div class="mega-col">
+                          <h4 class="mega-heading">Archive</h4>
+                          <ul>
+                            <li><a href="meetings.html">Meeting Recaps</a></li>
+                            <li><a href="presentations.html">Presentations</a></li>
+                            <li><a href="chat-resources.html">Chat Resources</a></li>
+                          </ul>
+                        </div>
+                      </div>
                     </li>
                     <li class="has-dropdown">
                       <button class="dropdown-toggle" aria-expanded="false" aria-haspopup="true">About <span class="caret" aria-hidden="true">▾</span></button>
                       <ul class="dropdown-menu">
-                        <li><a href="glossary.html">Glossary</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
-                        <li><a href="github-actions.html">How We Use GitHub Actions</a></li>
-                        <li><a href="cloud-deployment.html">How We Deploy to GCP</a></li>
+                        <li><a href="about-shawn-nunley.html">About Shawn</a></li>
+                        <li><a href="contribute.html">Contribute</a></li>
+                        <li><a href="contribute-resources.html">Add a Resource</a></li>
                       </ul>
                     </li>
+                    <li class="nav-cta-item"><a href="https://csoh.kit.com/39feb4f397" class="nav-cta" target="_blank" rel="noopener noreferrer">Join Friday Zoom →</a></li>
                 </ul>
             </nav>
         </div>
@@ -696,11 +710,11 @@
       <div class="footer-section">
         <h3>Explore</h3>
         <ul>
-          <li><a href="/learning-path.html">Learning Path</a></li>
-          <li><a href="/resources.html">Resources</a></li>
-          <li><a href="/news.html">News</a></li>
-          <li><a href="/sessions.html">Zoom Sessions</a></li>
-          <li><a href="/meetings.html">Meeting Recaps</a></li>
+          <li><a href="learning-path.html">Learning Path</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="news.html">News</a></li>
+          <li><a href="sessions.html">Zoom Sessions</a></li>
+          <li><a href="meetings.html">Meeting Recaps</a></li>
         </ul>
       </div>
       <div class="footer-section">
@@ -709,17 +723,24 @@
           <li><a href="mailto:admin@csoh.org">Contact</a></li>
           <li><a href="https://csoh.kit.com/39feb4f397" target="_blank" rel="noopener noreferrer">Mailing List</a></li>
           <li><a href="https://github.com/CloudSecurityOfficeHours/csoh.org" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/rss.html">RSS Feed</a></li>
-          <li><a href="/contribute.html">Contribute</a></li>
+          <li><a href="rss.html">RSS Feed</a></li>
+          <li><a href="contribute.html">Contribute</a></li>
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h3>Developer Docs</h3>
+        <ul>
+          <li><a href="github-actions.html">GitHub Actions</a></li>
+          <li><a href="cloud-deployment.html">Deploy to GCP</a></li>
         </ul>
       </div>
     </div>
     <div class="footer-bottom">
       <p>&copy; 2023-2026 Cloud Security Office Hours</p>
       <ul class="footer-legal">
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="/security-policy.html">Security</a></li>
+        <li><a href="privacy.html">Privacy</a></li>
+        <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>


### PR DESCRIPTION
## Summary
- Removes the **About Shawn** link from the About dropdown (now: Contribute, Add a Resource).
- The [about-shawn-nunley.html](https://csoh.org/about-shawn-nunley.html) page still exists; it just isn't surfaced in the nav.

## Test plan
- [x] Re-ran `tools/redesign_nav.py`; About dropdown no longer contains "About Shawn" on root and subdir pages
- [x] Page itself untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)