### PR TITLE
Add CISA ScubaGear to Security Tools & Platforms

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -5230,7 +5230,25 @@
         <li><a href="about.html">About</a></li>
         <li><a href="privacy.html">Privacy</a></li>
         <li><a href="code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="security-policy.html">Security</a></li>
+        <li><a href="security-policy.html">Security</a>
+
+    <a href="https://github.com/cisagov/scubagear" target="_blank" class="card-link" rel="noopener noreferrer">
+        <div class="resource-card" data-tooltip="Automated PowerShell tool from CISA that audits your Microsoft 365 tenant against the SCuBA secure configuration baselines, covering Entra ID, Exchange, Teams, SharePoint, OneDrive, Defender, and Power Platform. Outputs a detailed HTML report with pass/fail findings and remediation guidance for each control — ideal for compliance teams running M365 hardening assessments or preparing for FedRAMP audits. Requires PowerShell 5.1+ and a Global Reader (or equivalent) account in the target tenant.">
+            <img src="img/previews/github-com-cisagov-scubagear.jpg" alt="CISA Scuba Gear preview" class="resource-preview" loading="lazy" decoding="async" onerror="this.style.display='none'">
+            <h3>CISA Scuba Gear</h3>
+            <p>ScubaGear is an assessment tool that verifies that a Microsoft 365 (M365) tenant’s configuration conforms to the policies described in the Secure Cloud Business Applications (SCuBA) Secure Configuration Baseline documents.</p>
+            <div class="resource-tags">
+                <span class="tag">Azure</span>
+            <span class="tag">Tool</span>
+            <span class="tag">Vulnerability Testing</span>
+            <span class="tag">Penetration Testing</span>
+            <span class="tag">Cloud Scanning</span>
+            <span class="tag">Compliance</span>
+            <span class="tag">Free</span>
+            <span class="tag">Open Source</span>
+            </div>
+        </div>
+    </a></li>
       </ul>
     </div>
   </footer>

--- a/resources.html
+++ b/resources.html
@@ -2241,6 +2241,22 @@
                             </div>
                         </div>
                     </a>
+                    <a href="https://github.com/cisagov/ScubaGear" target="_blank" class="card-link" rel="noopener noreferrer">
+                        <div class="resource-card" data-tooltip="Automated PowerShell tool from CISA that audits your Microsoft 365 tenant against the SCuBA secure configuration baselines, covering Entra ID, Exchange, Teams, SharePoint, OneDrive, Defender, and Power Platform. Outputs a detailed HTML report with pass/fail findings and remediation guidance for each control — ideal for compliance teams running M365 hardening assessments or preparing for FedRAMP audits. Requires PowerShell 5.1+ and a Global Reader (or equivalent) account in the target tenant.">
+                            <img src="img/previews/github-com-cisagov-scubagear.jpg" alt="CISA ScubaGear preview" class="resource-preview" loading="lazy" decoding="async" onerror="this.style.display='none'">
+                            <h3>CISA ScubaGear</h3>
+                            <p>ScubaGear is an assessment tool that verifies that a Microsoft 365 tenant's configuration conforms to the policies described in the SCuBA Secure Configuration Baseline documents, covering Entra ID, Exchange, Teams, SharePoint, OneDrive, Defender, and Power Platform.</p>
+                            <div class="resource-tags">
+                                <span class="tag">Azure</span>
+                                <span class="tag tool">Tool</span>
+                                <span class="tag">Vulnerability Testing</span>
+                                <span class="tag">Cloud Scanning</span>
+                                <span class="tag">Compliance</span>
+                                <span class="tag">Free</span>
+                                <span class="tag">Open Source</span>
+                            </div>
+                        </div>
+                    </a>
                 </div>
             </div>
         </div>
@@ -5230,25 +5246,7 @@
         <li><a href="about.html">About</a></li>
         <li><a href="privacy.html">Privacy</a></li>
         <li><a href="code-of-conduct.html">Code of Conduct</a></li>
-        <li><a href="security-policy.html">Security</a>
-
-    <a href="https://github.com/cisagov/scubagear" target="_blank" class="card-link" rel="noopener noreferrer">
-        <div class="resource-card" data-tooltip="Automated PowerShell tool from CISA that audits your Microsoft 365 tenant against the SCuBA secure configuration baselines, covering Entra ID, Exchange, Teams, SharePoint, OneDrive, Defender, and Power Platform. Outputs a detailed HTML report with pass/fail findings and remediation guidance for each control — ideal for compliance teams running M365 hardening assessments or preparing for FedRAMP audits. Requires PowerShell 5.1+ and a Global Reader (or equivalent) account in the target tenant.">
-            <img src="img/previews/github-com-cisagov-scubagear.jpg" alt="CISA Scuba Gear preview" class="resource-preview" loading="lazy" decoding="async" onerror="this.style.display='none'">
-            <h3>CISA Scuba Gear</h3>
-            <p>ScubaGear is an assessment tool that verifies that a Microsoft 365 (M365) tenant’s configuration conforms to the policies described in the Secure Cloud Business Applications (SCuBA) Secure Configuration Baseline documents.</p>
-            <div class="resource-tags">
-                <span class="tag">Azure</span>
-            <span class="tag">Tool</span>
-            <span class="tag">Vulnerability Testing</span>
-            <span class="tag">Penetration Testing</span>
-            <span class="tag">Cloud Scanning</span>
-            <span class="tag">Compliance</span>
-            <span class="tag">Free</span>
-            <span class="tag">Open Source</span>
-            </div>
-        </div>
-    </a></li>
+        <li><a href="security-policy.html">Security</a></li>
       </ul>
     </div>
   </footer>


### PR DESCRIPTION
## Summary

- Adds CISA ScubaGear to the Security Tools \& Platforms section of `resources.html`
- Single file change — no workflow or config files touched

## Resource

**Name:** CISA ScubaGear  
**URL:** https://github.com/cisagov/ScubaGear  
**Category:** Security Tools \& Platforms  
**Tags:** Azure, Tool, Vulnerability Testing, Cloud Scanning, Compliance, Free, Open Source

ScubaGear is an automated PowerShell assessment tool from CISA that verifies a Microsoft 365 tenant's configuration against the SCuBA Secure Configuration Baseline documents, covering Entra ID, Exchange, Teams, SharePoint, OneDrive, Defender, and Power Platform.

## Notes

Replaces PR #768, which was closed because it accidentally included deletions of upstream GitHub Actions workflow files. This PR is a clean rebase off current main with only the resource card change.

## Test plan

- [ ] Card renders correctly in Security Tools \& Platforms section
- [ ] Tooltip displays on hover
- [ ] Tags display correctly
- [ ] URL passes automated safety check