### PR TITLE
Weekly docs review — 2026-06-19

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -216,7 +216,7 @@ Every workflow has its own header banner - but if you just want to know "what ru
 | Workflow | When | What it does | Where the report lands |
 | --- | --- | --- | --- |
 | [`check-pagespeed.yml`](.github/workflows/check-pagespeed.yml) | Mon 14:00 | Google PageSpeed Insights (mobile + desktop) | Appends row to `seo-audits/SCORECARD.md`; opens issue on regression |
-| [`run-seo-audit.yml`](.github/workflows/run-seo-audit.yml) | Mon 14:15 | Structural SEO check across 178 indexable pages | Appends row to `seo-audits/SCORECARD.md`; opens issue on regression |
+| [`run-seo-audit.yml`](.github/workflows/run-seo-audit.yml) | Mon 14:15 | Structural SEO check across 190 indexable pages | Appends row to `seo-audits/SCORECARD.md`; opens issue on regression |
 | [`check-reading-list-staleness.yml`](.github/workflows/check-reading-list-staleness.yml) | 1st of month, 07:00 | RSS-feed staleness check on `cloud-security-reading-list.html` | Opens or refreshes a sticky issue labeled `reading-list-staleness` |
 
 A few patterns worth knowing before you touch any of these:

--- a/conferences.html
+++ b/conferences.html
@@ -163,7 +163,7 @@
     {
       "@type": "ListItem",
       "position": 10,
-      "url": "https://www.blackhat.com/upcoming.html",
+      "url": "https://www.blackhat.com/",
       "name": "Black Hat Europe / Asia / MEA"
     },
     {


### PR DESCRIPTION
Automated weekly documentation review pass — 2026-06-19. Scoped to all root-level .html files, `/breaches/`, `/portfolio/`, and all `.md` files at root and `/docs`. Meeting pages skipped (auto-generated).

## Fixes applied

- **`conferences.html`** — JSON-LD `ItemList` entry for "Black Hat Europe / Asia / MEA" pointed to `https://www.blackhat.com/upcoming.html`, which returns **HTTP 403** (`host_not_allowed`). Changed to `https://www.blackhat.com/` (the base URL, which the visible card was already using correctly). Verified with `curl -ILs`.

- **`DEVELOPMENT.md`** — "Workflows at a Glance" table described `run-seo-audit.yml` as checking "178 indexable pages." Recent automated audit reports (2026-06-01, 2026-06-10, 2026-06-15) consistently show **190 indexable pages**. Updated to match.

## Needs human review

1. **Resource count inconsistency** — `README.md` (lines 161, 341, 564) and `DEVELOPMENT.md` (line 143) say resources are **"280+"**, but every HTML page (`index.html`, `about.html`, `resources.html`, stat strip, JSON-LD) says **"240+"**. The seo-audit from 2026-05-17 documents a `200+ → 240+` refresh on the HTML side. One set of numbers is wrong; needs a human to count actual resources in `resources.html` and reconcile README/DEVELOPMENT.md vs. the site pages.

2. **`about.html` and `mentorship.html` missing per-page OG images** — Both pages use `https://csoh.org/img/og/index.jpg` as their `og:image` and `twitter:image`. Neither `/img/og/about.jpg` nor `/img/og/mentorship.jpg` exist. Per DEVELOPMENT.md conventions, every indexable page should have a unique 1200×630 OG card (not `index.jpg`). Fix: add both pages to `PAGES` in `tools/generate_og_images.py` and run the generator.

3. **`security-policy.html` "coming soon" item (line 363)** — Responsible disclosure page lists "Add your name to a security researchers acknowledgments section (coming soon)" as a benefit of reporting. This has been placeholder text for some time. Either implement the acknowledgments section or remove the line.

4. **Breach pages `article:published_time` uses `YEAR-01-01` placeholder** — All 10 breach pages use January 1 of the breach year as the `article:published_time` meta tag (e.g. `2023-01-01` for Scattered Spider / MGM, which occurred in September 2023). These are clearly placeholders. Decision needed: use the actual breach month, or use the page's creation date (which is more correct semantically — `article:published_time` refers to the article, not the incident).

5. **`chat-resources.html` data not updated since 2026-05-01** — The latest `data-date` entry in the page is `2026-05-01` (7 weeks ago). The `min`/`max` date filter inputs are correctly set to match the data range, so no UI bug — but it surfaces that no new chat URLs have been added from recent Friday sessions. This may be intentional if the import pipeline is paused; flagging so it doesn't go unnoticed.

6. **`chat-resources.html` meta description too short** — Current: `"URLs shared during Cloud Security Office Hours chat sessions."` (61 chars). Recommended range is 100–165 chars for Google SERP display. Could be expanded to something like: `"580+ URLs shared during Cloud Security Office Hours Friday Zoom sessions — tools, CVEs, research, and community links, filterable by date, person, and category."`

## Nothing-to-fix areas

- **Copyright years**: All footers correctly show `© 2023-2026 Cloud Security Office Hours`. README and LICENSE also correct. ✓
- **Navigation consistency**: Spot-checked across 6 pages (index, about, about-shawn-nunley, community, faq, mentorship). Nav is identical across all — no drift. ✓
- **Accessibility**: No `alt=""`, no images missing `alt`, no empty anchor text found across sampled pages. ✓
- **Founder bio accuracy** (`about-shawn-nunley.html`): Career timeline math checks out — 1984 to 2026 = 42 years; security from 1996 = 30 years; cloud security from 2018 = 8 years. Matches hero text and JSON-LD. ✓
- **Founding date consistency**: `2023-02` (February 2023) consistent across all JSON-LD, body copy, and meta. ✓
- **Breach content accuracy**: Breach dates and incident descriptions checked against README kill-chain table. No stale "ongoing" language on resolved incidents. Promptware correctly marked 2024-2026. ✓
- **Internal links**: All href targets in navigation menus resolve to existing files. ✓
- **README accuracy vs. repo layout**: File structure trees in README.md match actual repo layout. All referenced tools, workflows, and scripts exist. ✓
- **Sessions/Meetings stale language**: `sessions.html` and `meetings.html` contain no hardcoded future dates or "upcoming" language for past events. ✓
- **Portfolio pages**: All 7 portfolio walkthroughs exist and are correctly linked from the hub page. ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArhEf5LJaVzwojo8DbYD3K)_