### PR TITLE
Weekly docs review — 2026-06-26

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -312,7 +312,7 @@ Whether you're fixing a typo or rewriting a section, the process is the same.
 - [glossary.html](glossary.html) - 300+ terms with cross-links
 - [faq.html](faq.html) - Frequently asked questions
 - [github-actions.html](github-actions.html) - GitHub Actions explainer
-- [cloud-deployment.html](cloud-deployment.html) - How csoh.org itself deploys to GCP
+- [cloud-deployment.html](cloud-deployment.html) - How csoh.org itself deploys to AWS, GCP, and Azure
 - [breach-timeline.html](breach-timeline.html) - Breach kill chain index (per-breach pages live in `breaches/`)
 - [threat-research.html](threat-research.html) - Cloud threat research source directory (incl. Supply Chain Attacks)
 - [code-of-conduct.html](code-of-conduct.html) - Community standards

--- a/faq.html
+++ b/faq.html
@@ -338,7 +338,7 @@
 
             <details class="meeting-topics">
                 <summary><strong>Does CSOH cost anything?</strong></summary>
-                <p>No. CSOH is 100% free. Donations via <a href="https://www.paypal.com/us/home" target="_blank" rel="noopener noreferrer">PayPal</a> are optional and not required to attend or participate.</p>
+                <p>No. CSOH is 100% free. Donations via <a href="https://www.paypal.com/biz/profile/cloudsec" target="_blank" rel="noopener noreferrer">PayPal</a> are optional and not required to attend or participate.</p>
             </details>
 
             <h2 id="join">Joining &amp; the Friday Session</h2>
@@ -424,7 +424,7 @@
 
             <details class="meeting-topics">
                 <summary><strong>What's the difference between the Resources page and the CTFs page?</strong></summary>
-                <p><a href="resources.html">Resources</a> is a broad catalog (200+) covering labs, tools, certifications, training, AI security, and jobs. <a href="ctfs.html">CTFs</a> is a focused directory of hands-on cloud CTF challenges with status and difficulty.</p>
+                <p><a href="resources.html">Resources</a> is a broad catalog (240+) covering labs, tools, certifications, training, AI security, and jobs. <a href="ctfs.html">CTFs</a> is a focused directory of hands-on cloud CTF challenges with status and difficulty.</p>
             </details>
 
             <details class="meeting-topics">


### PR DESCRIPTION
Automated weekly documentation review. Scope: all `.html` files, `README.md`, `CONTRIBUTING.md`, other `.md` files at repo root and `/docs`.

---

## Fixes applied

### `faq.html` — PayPal donation link was broken
- **Line 341:** `href="https://www.paypal.com/us/home"` → `href="https://www.paypal.com/biz/profile/cloudsec"`
- The old link sent visitors to the generic PayPal homepage, not the CSOH donation page. `index.html` already uses the correct `/biz/profile/cloudsec` URL; this brings `faq.html` in line.

### `faq.html` — Resources count was stale
- **Line 427:** `(200+)` → `(240+)` in the "Resources vs CTFs" FAQ answer
- `resources.html` meta description, OG tags, and JSON-LD all say 240+. The FAQ was the only place still saying 200+.

### `CONTRIBUTING.md` — cloud-deployment.html description was wrong
- **Line 315:** "How csoh.org itself deploys to GCP" → "How csoh.org itself deploys to AWS, GCP, and Azure"
- `cloud-deployment.html` covers the full three-cloud deployment (AWS S3/CloudFront, GCP Cloud Run, Azure Blob). The old description implied GCP only.

---

## Needs human review

### Resource count discrepancy: "240+" vs "280+" across docs
- All HTML pages (`index.html`, `resources.html`, `about.html`, `faq.html`) consistently say **240+**.
- `README.md` (lines 161, 341) and `DEVELOPMENT.md` (line 143) say **280+**.
- The weekly auto-update script bumps the `<span id="visibleCount">` counter in `resources.html` but does not update meta descriptions or doc files. The actual current count needs a human to verify — if 280+ is correct, the HTML pages' meta descriptions need updating; if 240+ is correct, the .md files need correcting.

### `about.html` — OG/Twitter image uses `index.jpg`
- `about.html` `og:image` and `twitter:image` both point to `https://csoh.org/img/og/index.jpg`.
- No `img/og/about.jpg` exists. Either create a dedicated about-page OG image and update the tags, or leave as-is if the homepage OG image is acceptable for social shares of the About page.

### `about-shawn-nunley.html` — "8+ years" cloud security may be stale
- Meta description (line 9) and JSON-LD (line 68) say "8+ years specializing in cloud security."
- The career timeline shows cloud security focus starting ~2017 (Barracuda), which would be 9 years in 2026. Human judgment call on whether to update to "9+" or leave the conservative "8+".

### `DEVELOPMENT.md` — indexable page count inconsistency
- `DEVELOPMENT.md` line 219 says "178 indexable pages."
- `README.md` line 897 says `run_seo_audit.py` covers "190 indexable HTML pages."
- These counts are likely auto-derived and drift as new pages are added; the correct value needs a fresh `python tools/run_seo_audit.py` run or a count of actual `.html` files.

### `SECURITY.md` — "Server: LiteSpeed" known limitation may be outdated
- The Known Limitations table (bottom of file) includes: `Server: LiteSpeed on HTTP redirect | Hosting limitation | The HTTP (port 80) redirect response leaks the server type.`
- The site migrated from LiteSpeed shared hosting to multi-cloud (Cloudflare/GCP/AWS/Azure) and now serves via nginx + Cloudflare. This limitation likely no longer applies. Recommend removing or updating this row.

---

## Nothing-to-fix areas

- `sessions.html` — nav, footer, metadata, content all clean
- `faq.html` (other than the two fixes above) — accurate and up to date
- `about.html` — body content accurate (OG image flagged above as human-review)
- `SECURITY.md` — comprehensive and accurate; GitHub Actions SHAs, CSP, auth model all look current
- `CONTRIBUTING_RESOURCES.md` — accurate
- Footer copyright `© 2023-2026` — correct
- JSON-LD structured data on reviewed pages — valid and consistent with page content
- Nav links across reviewed pages — consistent
- Heading order on reviewed pages — no skipped heading levels observed
- Alt text on reviewed pages — present and descriptive
- No "new in 2024" or similar stale year references found in body content
- External link sample checks (PayPal, Kit, GoatCounter) — blocked by proxy environment; GitHub Actions link-check workflow covers this in CI

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmFch3zvENNxBsJhfvojB)_