### PR TITLE
Weekly docs review — 2026-07-24

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -140,7 +140,7 @@ csoh.org/
 ├── meetings.html                    # Weekly meeting recaps → `meetings/`
 ├── presentations.html               # Recorded presentation archive
 ├── chat-resources.html              # Community-shared URLs from Zoom chat
-├── resources.html                   # 380+ curated resources (largest page; auto-refreshed weekly)
+├── resources.html                   # 410+ curated resources (largest page; auto-refreshed weekly)
 ├── news.html                        # Auto-generated news articles
 ├── rss.html                         # RSS subscription landing page
 │

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The vendor-neutral curriculum, written by practitioners. This catalog mirrors th
 |---|---|
 | 🧭 [Cloud Security Careers](https://csoh.org/cloud-security-careers.html) | Roles, salary bands, interview formats, portfolio projects |
 | 🛣️ [Cloud Security Learning Path](https://csoh.org/learning-path.html) | Beginner → working practitioner roadmap with milestones |
-| 🪜 [Help Desk → Cloud Security](https://csoh.org/help-desk-to-cloud-security.html) | The realistic transition from IT support |
+| 🪜 [Help Desk → Cloud Security](https://csoh.org/breaking-into-cloud-security.html) | The realistic transition from IT support |
 | 🎓 [Cloud Security Certifications](https://csoh.org/cloud-security-certifications.html) | CCSK, CCSP, AWS, Azure, GCP, CKS compared side by side |
 | 🎓 [Cloud Security Degree Programs](https://csoh.org/cloud-security-degree-programs.html) | Academic paths, what to look for, named US/international universities |
 | 🧰 [Cloud Security Home Lab](https://csoh.org/cloud-security-home-lab.html) | Free-tier setups, budget guardrails, kill-switches |
@@ -158,7 +158,7 @@ Cross-cutting entry points that sit outside the topic menus (everything else now
 
 | Resource | What it is |
 |---|---|
-| 🛡️ [Resources Directory](https://csoh.org/resources.html) | 370+ tools, labs, CTFs, certifications - top-level nav link, auto-refreshed weekly |
+| 🛡️ [Resources Directory](https://csoh.org/resources.html) | 410+ tools, labs, CTFs, certifications - top-level nav link, auto-refreshed weekly |
 | 🔍 [Site-wide Search](https://csoh.org/search.html) | MiniSearch full-text index across every page, with section-anchor results and synonym expansion |
 
 ---
@@ -212,7 +212,7 @@ Academic paths for cloud security: when a degree pays off, degree types and what
 Roles and salary bands, what hiring managers actually look for, interview formats, portfolio projects, and how to translate from adjacent roles. FAQ schema. The careers hub fans out to a **role-in-depth series** and a **portfolio-projects hub** (below).
 
 ### 🧑‍💼 Career Roles, In Depth (`cloud-security-*.html`)
-A series of one-page-per-role deep dives covering day-to-day work, the skills that actually matter, salary signals, and how to break in: Cloud Security Engineer, Cloud Security Architect (Staff+ IC), IAM / Identity Architect, Cloud AppSec / IaC Security Engineer, CSPM / CNAPP Analyst, Cloud Detection Engineer, Cloud Incident Responder (DFIR), Cloud Penetration Tester / Red Team, Security SRE / Platform Security Engineer, Cloud GRC / Compliance Engineer, Cloud Security Sales Engineer, and Cloud Security Customer Success Engineer. `help-desk-to-cloud-security.html` is the companion transition guide for people coming from IT support. Each role page carries FAQ schema.
+A series of one-page-per-role deep dives covering day-to-day work, the skills that actually matter, salary signals, and how to break in: Cloud Security Engineer, Cloud Security Architect (Staff+ IC), IAM / Identity Architect, Cloud AppSec / IaC Security Engineer, CSPM / CNAPP Analyst, Cloud Detection Engineer, Cloud Incident Responder (DFIR), Cloud Penetration Tester / Red Team, Security SRE / Platform Security Engineer, Cloud GRC / Compliance Engineer, Cloud Security Sales Engineer, and Cloud Security Customer Success Engineer. Each role page carries FAQ schema.
 
 ### 🛠️ Cloud Security Portfolio Projects (`cloud-security-portfolio-projects.html` + `portfolio/`)
 A hub of build-it-yourself projects that demonstrate real cloud-security skill to hiring managers, each with a full step-by-step walkthrough under `portfolio/`: build a multi-account AWS Org with SCPs, walk every CloudGoat scenario, write a CNAPP comparison, build 5 detections in a lab SIEM, run a Prowler audit and Terraform the fixes, recreate the Capital One breach end to end, and ship a first OSS contribution to a cloud-security project.
@@ -561,7 +561,6 @@ csoh.org/
 │                                      #   detection-engineer, incident-responder, penetration-tester,
 │                                      #   platform-engineer, grc-engineer, sales-engineer,
 │                                      #   customer-success-engineer (FAQ schema)
-├── help-desk-to-cloud-security.html   # Transition guide: IT help desk -> cloud security
 ├── github-actions.html         # Learn GitHub Actions via our heavily-commented workflows
 ├── cloud-deployment.html       # Multi-cloud deploy architecture (the dogfooded stack)
 ├── terraform.html              # Learn Terraform via our own multi-cloud IaC

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
   <meta name="description"
-    content="Cloud Security Office Hours: 2000+ pros, 370+ vendor-neutral resources, AWS/Azure/GCP CTFs, labs, certifications & free Friday Zoom sessions.">
+    content="Cloud Security Office Hours: 2000+ pros, 410+ vendor-neutral resources, AWS/Azure/GCP CTFs, labs, certifications & free Friday Zoom sessions.">
   <meta name="keywords"
     content="cloud security, AWS security, Azure security, GCP security, kubernetes security, CTF challenges, CSPM, CNAPP, cloud security training, security certifications, penetration testing, cloud security community">
   <title>Cloud Security Office Hours - Free Weekly Community</title>
@@ -28,7 +28,7 @@
   <!-- Open Graph Meta Tags -->
   <meta property="og:title" content="Cloud Security Office Hours (CSOH)">
   <meta property="og:description"
-    content="Join 2000+ cloud security professionals. 370+ curated resources, CTF challenges, training labs, and free weekly Zoom sessions. 100% vendor-neutral.">
+    content="Join 2000+ cloud security professionals. 410+ curated resources, CTF challenges, training labs, and free weekly Zoom sessions. 100% vendor-neutral.">
   <meta property="og:site_name" content="Cloud Security Office Hours">
   <meta property="og:locale" content="en_US">
   <meta property="og:type" content="website">
@@ -111,7 +111,7 @@
           "@type": "FAQPage",
           "mainEntity": [
             { "@type": "Question", "name": "What is Cloud Security Office Hours (CSOH)?", "acceptedAnswer": { "@type": "Answer", "text": "Cloud Security Office Hours (CSOH) is a weekly community gathering for cloud security professionals that started in February 2023. We have grown to over 2000 members. Every Friday at 7am PT, we meet on Zoom to discuss cloud security topics, share knowledge, and learn from each other. It's completely free and vendor-neutral." } },
-            { "@type": "Question", "name": "How many cloud security resources does CSOH provide?", "acceptedAnswer": { "@type": "Answer", "text": "CSOH provides 370+ curated cloud security resources including CTF challenges for AWS, Azure, GCP, and Kubernetes; hands-on training labs; CSPM and CNAPP security tools; professional certifications; and penetration testing platforms. All resources are free and updated weekly." } },
+            { "@type": "Question", "name": "How many cloud security resources does CSOH provide?", "acceptedAnswer": { "@type": "Answer", "text": "CSOH provides 410+ curated cloud security resources including CTF challenges for AWS, Azure, GCP, and Kubernetes; hands-on training labs; CSPM and CNAPP security tools; professional certifications; and penetration testing platforms. All resources are free and updated weekly." } },
             { "@type": "Question", "name": "When are the CSOH Zoom sessions held?", "acceptedAnswer": { "@type": "Answer", "text": "CSOH Zoom sessions are held every Friday at 7am PT. Sessions include presentations from industry experts, open discussions, and Q&A. All sessions are 100% free with no vendor pitches and no sponsored content." } },
             { "@type": "Question", "name": "Is CSOH free to join?", "acceptedAnswer": { "@type": "Answer", "text": "Yes, CSOH is completely free. All resources, Zoom sessions, and community access are provided at no cost. We are vendor-neutral and do not do any marketing. The community is run by volunteers." } },
             { "@type": "Question", "name": "What cloud platforms does CSOH cover?", "acceptedAnswer": { "@type": "Answer", "text": "CSOH covers security for all major cloud platforms including Amazon Web Services (AWS), Microsoft Azure, Google Cloud Platform (GCP), and Kubernetes. Resources include multi-cloud security tools, CTF challenges, and training labs for each platform." } }

--- a/kevin-mitnick.html
+++ b/kevin-mitnick.html
@@ -478,10 +478,7 @@
                 </figure>
 
                 <figure class="page-photo">
-                  <picture>
-                    <source srcset="/img/IMG_0228_1.jpeg" type="image/jpeg">
-                    <img src="/img/IMG_0228_1.jpeg" alt="Kevin Mitnick" width="1880" height="1253" loading="lazy" decoding="async">
-                  </picture>
+                  <img src="/img/IMG_0228_1.jpeg" alt="Kevin Mitnick speaking at an event" width="1880" height="1253" loading="lazy" decoding="async">
                   <figcaption>Kevin, in his element.</figcaption>
                 </figure>
             </div>

--- a/resources.html
+++ b/resources.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
     <meta name="description"
-        content="370+ curated cloud security resources: AWS/Azure/GCP/Kubernetes CTFs, CSPM/CNAPP tools, certifications, training labs and pentest platforms.">
+        content="410+ curated cloud security resources: AWS/Azure/GCP/Kubernetes CTFs, CSPM/CNAPP tools, certifications, training labs and pentest platforms.">
     <meta name="keywords"
         content="cloud security resources, AWS pentesting, Azure security tools, GCP CTF, kubernetes goat, CSPM tools, CNAPP platforms, cloud security certifications, security labs, vulnerable by design, IAM security, cloud CTF">
     <title>Cloud Security Resources - Cloud Security Office Hours</title>
@@ -24,7 +24,7 @@
 
     <meta property="og:title" content="Cloud Security Resources - Cloud Security Office Hours">
     <meta property="og:description"
-        content="370+ curated cloud security resources: CTF challenges, CSPM/CNAPP tools, certifications, hands-on labs, and penetration testing platforms.">
+        content="410+ curated cloud security resources: CTF challenges, CSPM/CNAPP tools, certifications, hands-on labs, and penetration testing platforms.">
     <meta property="og:site_name" content="Cloud Security Office Hours">
     <meta property="og:locale" content="en_US">
     <meta property="og:type" content="website">


### PR DESCRIPTION
Automated weekly docs review. Scope: all root `.html` files, root `.md` files (README, CONTRIBUTING, DEVELOPMENT, CLAUDE). 95 HTML pages total checked via targeted pattern searches; 5 files directly read in full; key structural patterns grepped across the full repo.

## Fixes applied

### README.md — broken URL for Help Desk guide
`help-desk-to-cloud-security.html` was referenced in three places but does not exist in the repository (confirmed via `ls`; also absent from any prior HTML file link). The page that actually covers this topic is `breaking-into-cloud-security.html` (which includes "help desk to cloud security" in its keywords and is already linked from `cloud-security-careers.html` and `cloud-security-customer-success-engineer.html` as the help-desk transition guide).

- Line 96 (Careers table): updated URL to `breaking-into-cloud-security.html`
- Line 215 (Career Roles section): removed the sentence naming the missing file as "the companion transition guide"
- Line 564 (file structure tree): removed the stale `help-desk-to-cloud-security.html` entry

### Resource count consistency — 370+/380+ → 410+
The `<!--count:resources_floor-->` automation already shows **410+** in the site hero text and FAQ visible content (index.html). The actual `visibleCount` span on resources.html shows **424**. Several hardcoded or non-automated values were still saying 370+ or 380+:

- `index.html` meta description: 370+ → 410+
- `index.html` OG description: 370+ → 410+
- `index.html` JSON-LD FAQ answer: 370+ → 410+
- `resources.html` meta description: 370+ → 410+
- `resources.html` OG description: 370+ → 410+
- `README.md` Resources Directory table row: 370+ → 410+
- `DEVELOPMENT.md` file structure comment: 380+ → 410+

### kevin-mitnick.html — malformed `<picture>` element
A `<picture>/<source>` block used `type="image/jpeg"` with a JPEG `srcset` that duplicated the `<img src>` exactly. The `<picture>` pattern is for offering alternative formats (e.g. WebP → JPEG fallback); JPEG-to-JPEG provides no benefit and the `source` element is technically incorrect for this use. Simplified to a plain `<img>` tag. Also improved alt text from the generic `"Kevin Mitnick"` to `"Kevin Mitnick speaking at an event"`.

## Needs human review

- **`index.html` stat strip (line 335)**: Hardcodes `370+` in the pull-quote stat block — a separate hardcoded value that the count automation does not update. Should it be bumped to 410+ or 424+? Left alone because it's visually prominent and the exact number to use is a judgment call.
- **`README.md` line 341**: `<!--count:resources_floor-->380+<!--/count-->` — carries an automation marker but says 380+ while the same marker in `index.html` says 410+. The update-counts workflow may only target HTML files, not `.md` files. Worth confirming whether the automation is intentionally scoped to HTML only, and if so, updating the README count manually.
- **`security-policy.html` line 382**: "Add your name to a security researchers acknowledgments section (coming soon)" — may be stale if this feature was never built.
- **`resources.html` line 3810**: Inline description says "370+ links, vendor-neutral…" — separate hardcoded string inside a JS comment block; not updated by the automation.
- **`faq.html` and `about.html`**: Still say "370+" in visible content (e.g. FAQ answer at line 667, about.html line 313). These are managed by `sync_chrome.py` or hand-written content — confirm whether they should track the automation value.

## Nothing-to-fix areas

- **Copyright years**: All pages correctly show `© 2023-2026`
- **Nav/footer**: Consistent across all checked pages (managed by `sync_chrome.py`)
- **Sessions info**: Friday 7am PT, free, weekly since February 2023 — accurate
- **Kevin Mitnick dates**: Birth (1963-08-06) and death (2023-07-16) match schema.org structured data — accurate
- **CONTRIBUTING.md**: No significant inaccuracies found
- **"Free since 2023"** footer blurb: Factually accurate founding date, not stale
- **Meeting recap pages**: "upcoming" references in meeting summaries are past-event context, not stale
- **OG/Twitter images**: Present and consistent on checked pages
- **Heading order**: No issues observed in checked pages

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzW55got8DfLRLUNpW97G4)_