### PR TITLE
Weekly docs review — 2026-08-21

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -205,7 +205,7 @@ csoh.org/
 │                                    #   - read vendor/README.md before re-vendoring
 │
 ├── tools/                  # Python automation scripts (URL safety, normalization, previews, sitemap, presentations schema, glossary cross-linking, OG image generation incl. meeting variant, meeting → topic-page link injection, live edge-header verification)
-├── .github/workflows/      # CI/CD pipelines (15 workflows: update-news, update-resources, update-counts, deploy, normalize-urls, check-broken-links, check-url-safety, check-pagespeed, check-reading-list-staleness, check-meeting-staleness, check-conference-staleness, run-seo-audit, validate-html, lint, site-update-deploy)
+├── .github/workflows/      # CI/CD pipelines (20 workflows: update-news, update-resources, update-counts, deploy, normalize-urls, check-broken-links, check-url-safety, check-pagespeed, check-reading-list-staleness, check-meeting-staleness, check-conference-staleness, run-seo-audit, validate-html, lint, site-update-deploy, check-mobile-layout, deploy-qa, promote-qa, publish-recaps, weekly-docs-review)
 └── update_news.py          # News aggregation from 62 RSS feeds
 ```
 

--- a/README.md
+++ b/README.md
@@ -631,8 +631,9 @@ csoh.org/
 │
 │  ── Breach kill chains ──
 ├── breach-timeline.html        # Index of breach kill chains (per-breach pages in breaches/)
-├── breach-lessons.html         # Cross-incident synthesis: recurring root causes across the 20 chains
+├── breach-lessons.html         # Cross-incident synthesis: recurring root causes across the 45 chains
 ├── cloud-breach-year-in-review-2025.html  # The cloud/SaaS/supply-chain breaches that defined 2025
+├── cloud-breach-year-in-review-2026-h1.html  # 2026 first-half review (Jan-Jul 2026)
 ├── kevin-mitnick.html          # Special resource page
 │
 │  ── Governance + AI ──
@@ -760,7 +761,7 @@ csoh.org/
 ├── update_sri.py               # Updates SRI hashes & cache-bust params across HTML files
 ├── retire_merged_career_pages.py # One-off: repoint links to the merged "breaking in" page
 │
-├── .github/workflows/          # 15 CI/CD workflows (see "How Automation Works" below)
+├── .github/workflows/          # 20 CI/CD workflows (see "How Automation Works" below)
 │
 ├── seo-audits/                 # SEO audit reports + SCORECARD.md (excluded from deploy filters)
 ├── preview-mapping.json        # Metadata for resource previews
@@ -977,7 +978,7 @@ Edit the "Resource Categories" section in `index.html` to:
 
 This site uses **GitHub Actions workflows** to automate all major site updates. Every workflow file is commented line by line - they double as the teaching material behind [github-actions.html](https://csoh.org/github-actions.html), so read them if you want the full story.
 
-All 15 workflows, grouped by what they do. Times are UTC.
+The table below covers the 15 core workflows; `check-mobile-layout`, `deploy-qa`, `promote-qa`, `publish-recaps`, and `weekly-docs-review` are the remaining five (QA pipeline docs: `.github/workflows/QA_PIPELINE_README.md`). Times are UTC.
 
 **Content automation (writes to the site)**
 

--- a/breach-timeline.html
+++ b/breach-timeline.html
@@ -672,7 +672,7 @@
           <figcaption>Two takeaways: provider zero-days are vanishingly rare, and identity-adjacent failures (credentials + IAM + misconfig) account for ~80% of major incidents.</figcaption>
         </figure>
 
-        <p class="kc-coverage-note">Newest first. These kill chains run from the July 2026 Hugging Face intrusion back to 1990s social engineering, and reading them in either direction makes the same point: the tooling changed, the root causes did not. Fast-moving incidents are tracked first in the <a href="news.html">news feed</a>, with the recurring root causes distilled in <a href="breach-lessons.html">breach lessons</a> - which walks the same set in chronological order - and the <a href="cloud-breach-year-in-review-2025.html">2025 year in review</a>. The most instructive incidents graduate into full kill chains here.</p>
+        <p class="kc-coverage-note">Newest first. These kill chains run from the July 2026 Hugging Face intrusion back to 1990s social engineering, and reading them in either direction makes the same point: the tooling changed, the root causes did not. Fast-moving incidents are tracked first in the <a href="news.html">news feed</a>, with the recurring root causes distilled in <a href="breach-lessons.html">breach lessons</a> - which walks the same set in chronological order - and the <a href="cloud-breach-year-in-review-2026-h1.html">2026 first-half review</a>. The most instructive incidents graduate into full kill chains here.</p>
         <ul class="breach-list" role="list">
         <li class="breach-card" id="huggingface-openai-agent">
             <a class="breach-card-link" href="breaches/huggingface-openai-agent.html">


### PR DESCRIPTION
## Fixes applied

- **`README.md` — workflow count corrected (15 → 20)** — The directory-structure listing and the "How Automation Works" section both said "15 CI/CD workflows", but there are now 20 `.yml` files in `.github/workflows/`. Updated both instances and added a note listing the five workflows not covered by the existing table (`check-mobile-layout`, `deploy-qa`, `promote-qa`, `publish-recaps`, `weekly-docs-review`).

- **`README.md` — breach-lessons chain count corrected (20 → 45)** — The file-structure comment for `breach-lessons.html` said "recurring root causes across the 20 chains." The page title and metadata both say "45 Cloud Breaches." Updated the comment to match.

- **`README.md` — added `cloud-breach-year-in-review-2026-h1.html` to file structure** — The 2026 first-half review (published July 2026) was missing from the file-structure listing alongside the 2025 entry.

- **`DEVELOPMENT.md` — workflow count corrected (15 → 20)** — Same stale count in the directory-structure comment; updated the number and enumerated all 20 workflow names.

- **`breach-timeline.html` — updated year-in-review link in the coverage note** — The coverage paragraph linked to `cloud-breach-year-in-review-2025.html` as "the 2025 year in review." A 2026 first-half review now exists and covers all incidents the page discusses (including the July 2026 Hugging Face intrusion that the same paragraph names). Changed the link to point to `cloud-breach-year-in-review-2026-h1.html`. The 2025 review is still reachable via the hub link in the paragraph above.

## Needs human review

- **`README.md` line 520** — "the incidents that defined this past year are collected in the **2025 Cloud Breach Year in Review**" — "this past year" is still technically accurate (2025 is the most recently completed full year), but a reader in August 2026 might expect a pointer to the 2026 H1 review as well. Human judgment on whether to add a second link.

- **Workflow tables in README.md and DEVELOPMENT.md** — The detailed workflow tables (with schedule, description, and auto-merge columns) are still missing rows for the five newer workflows (`check-mobile-layout`, `deploy-qa`, `promote-qa`, `publish-recaps`, `weekly-docs-review`). Adding those rows would require pulling schedules and descriptions from each `.yml` file. Left for a human to fill in.

- **`about-shawn-nunley.html` — Shawn's job title** — The page carries `"jobTitle": "Solutions Architect, Majors"` and describes the role in body text. Cannot verify from the repo whether this is still current. Human should confirm.

## Nothing-to-fix areas

- **Copyright years** — All pages show `© 2023-2026 Cloud Security Office Hours`. Current.
- **Conference dates** (`conferences.html`) — All "Next:" dates are in the future (RSA 2027, DEF CON 35 2027, Black Hat USA 2027, Black Hat Europe Sep 2026, re:Invent Nov 2026, etc.). No stale dates found.
- **RSS feed count** — "62 sources" appears in README.md, DEVELOPMENT.md, and `faq.html`. Verified against `update_news.py` (62 entries in the `FEEDS` list). Correct.
- **Copyright and founding date** — "Founded February 2023" consistent across all pages checked.
- **Action SHAs in `SECURITY.md`** — The `Cyb3r-Jak3/html5validator-action` SHA `443b108eb8e134b63a1f8a8ba0c942d552608ed7` matches the current `validate-html.yml`. Verified.
- **Certifications content** — No retired or superseded certs found. The note about AWS replacing SCS-C02 with SCS-C03 in December 2025 is accurate historical context.
- **Zoom time** (`sessions.html`) — "Every Friday at 7am PT" consistent across all pages.
- **Alt text on content images** — No content images with empty alt text found in the scanned pages.
- **Markdown files** — `CONTRIBUTING.md`, `SECURITY.md`, `RSS_FEED_README.md` checked; no factual inaccuracies found.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjWTPAxbL7PvXAv3qBuzbw)_