### PR TITLE
Weekly docs review — 2026-09-04

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -221,7 +221,7 @@ csoh.org/
 │                                    #   - read vendor/README.md before re-vendoring
 │
 ├── tools/                  # Python automation scripts (URL safety, normalization, previews, sitemap, presentations schema, glossary cross-linking, OG image generation incl. meeting variant, meeting → topic-page link injection, live edge-header verification)
-├── .github/workflows/      # CI/CD pipelines (20 workflows: update-news, update-resources, update-counts, deploy, normalize-urls, check-broken-links, check-url-safety, check-pagespeed, check-reading-list-staleness, check-meeting-staleness, check-conference-staleness, run-seo-audit, validate-html, lint, site-update-deploy, check-mobile-layout, deploy-qa, promote-qa, publish-recaps, weekly-docs-review)
+├── .github/workflows/      # CI/CD pipelines (21 workflows: update-news, update-resources, update-counts, deploy, normalize-urls, check-broken-links, check-url-safety, check-pagespeed, check-reading-list-staleness, check-meeting-staleness, check-conference-staleness, run-seo-audit, validate-html, lint, site-update-deploy, check-mobile-layout, security-impact-review, deploy-qa, promote-qa, publish-recaps, weekly-docs-review)
 └── update_news.py          # News aggregation from 62 RSS feeds
 ```
 


### PR DESCRIPTION
Automated weekly documentation review for 2026-09-04. Scope: all 110 root HTML pages plus README.md, DEVELOPMENT.md, CONTRIBUTING.md, and other tracked `.md` docs.

## Fixes applied

- **`DEVELOPMENT.md` — workflow count wrong in directory tree comment** (`line 225`): The parenthetical list said "20 workflows" and omitted `security-impact-review`. Actual count from `.github/workflows/*.yml` is 21, matching the `<!--count:workflows-->21<!--/count-->` marker in README.md and the "Workflows at a Glance" table in DEVELOPMENT.md itself. Updated count to 21 and added the missing workflow name to the list.

## Needs human review

- **`meetings.html` — auto-generated recap references "upcoming RSA Conference 2024" in a 2026-01-16 meeting summary** (`line 1248`): A generated session digest contains the phrase "upcoming RSA Conference 2024" in what is dated a January 2026 recap. RSA 2024 is now almost two years in the past. This is in auto-generated content (`publish-recaps.yml` output); the fix may need to be applied at the recap source or via a re-generation, not a hand-edit.

- **`ai-ml-security.html` — OWASP LLM Top 10 2026 positions** (updated 2026-08-19): The page references the 2026 edition with specific item numbers. CLAUDE.md records that the weekly docs review previously confidently mis-stated 7 of 10 positions on this list. Accuracy requires fetching the canonical source (`api.github.com/repos/GenAI-Security-Project/GenAI-LLM-Top10/contents/2026/final`), which is outside scope for this automated pass. Recommend a human spot-check against that directory listing.

- **`cloud-security-penetration-tester.html` — "next year's engagements" phrasing now refers to the current year** (`line 455`): The sentence "AWS alone shipped several hundred new services and features in 2025 … will miss the paths that matter in the next year's engagements" was written in 2025 with "next year" meaning 2026. We are now in 2026, so the framing is slightly stale. This is prose-level wording; a human should decide whether to update (e.g., "current year's engagements" or "2026 and 2027 engagements").

## Nothing-to-fix areas

- **Copyright years**: All footers consistently read `© 2023–2026 Cloud Security Office Hours` — correct.
- **Nav and footer consistency**: Confirmed structurally identical across sampled pages (generated by `sync_chrome.py`).
- **Conference dates** (`conferences.html`): All "Next:" entries point to future dates (September 7–8, 2026 onward). No past event framed as upcoming.
- **Certification version claims**: CCSP SCS-C03 (replaced SCS-C02 December 2025), CCSK v5, AZ-500 retirement (August 31, 2026) all accurately stated.
- **Internal links** (`index.html`, `README.md`, `DEVELOPMENT.md`): All 110 root HTML pages verified present on disk and referenced in README and DEVELOPMENT.md (the latter via `<placeholder>` tokens). No broken internal links found.
- **README.md workflow count**: Correctly says 21 via `<!--count:workflows-->` marker.
- **ISO 27001:2022 transition**: "transition window for 2013-revision certificates closed in October 2025" correctly in past tense.
- **Wiz/Google acquisition**: Correctly stated as "announced 2025, closed March 2026."
- **"New in 202X" / "upcoming" / "register now" language**: No instances found referring to past events.
- **`vendor/` files**: Not touched (SRI-stamped, per-file change policy).
- **Auto-generated files**: `search-index.json`, `sitemap.xml`, `news.html` card blocks, meeting recaps not modified.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDXazGJtXdzfGpw6DwQnbM

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDXazGJtXdzfGpw6DwQnbM)_