### PR TITLE
Weekly docs review — 2026-09-11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,7 +311,7 @@ Whether you're fixing a typo or rewriting a section, the process is the same.
 - [cloud-security-certifications.html](cloud-security-certifications.html) - CCSK / CCSP / AWS / Azure / GCP / CKS comparison
 - [conferences.html](conferences.html) - Security and hacker conference directory
 - [ctfs.html](ctfs.html) - Cloud CTF directory
-- [glossary.html](glossary.html) - 310 terms with cross-links
+- [glossary.html](glossary.html) - 326 terms with cross-links
 - [faq.html](faq.html) - Frequently asked questions
 - [github-actions.html](github-actions.html) - GitHub Actions explainer
 - [cloud-deployment.html](cloud-deployment.html) - How csoh.org itself deploys to AWS, GCP, and Azure

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -334,8 +334,9 @@ QA run and is therefore unpromotable.
    `tools/site-publish.filter` (a deny-list). The GCP container gets `COPY . `
    minus `.dockerignore`, minus the Dockerfile's `rm`/`find` list, minus
    nginx's request-time denies. Three files have to agree, and nothing in CI
-   compares them. They *do* agree today - both sides resolve to the same 3231
-   files - but if you touch any of the three, check the other two.
+   compares them. They *do* agree today - both sides resolve to the same file
+   count - but if you touch any of the three, check the other two. Re-derive
+   the count rather than citing a figure here; it grows with content.
 
 3. **The housekeeping workflow's commits do not deploy.** `site-update-deploy.yml`
    re-stamps SRI, refreshes the sitemap, and generates previews, and every one
@@ -804,7 +805,7 @@ Always trust the live-site signals (PSI + GSC) over the codebase scorecard. The 
 | `tools/update_presentations_schema.py` | Regenerates `VideoObject` JSON-LD on `presentations.html` | **Don't edit** -- runs in CI on every deploy |
 | `tools/crosslink_glossary.py` | Adds `id="term-..."` to glossary `<dt>`s and hyperlinks every term mention in `<dd>`s | Run after adding/editing glossary entries |
 | `tools/crosslink_pages.py` | Hyperlinks first occurrence of each glossary term across all content pages | Run after adding/editing glossary entries (or after adding a new content page) |
-| `glossary.html` | Cloud-security glossary (310 terms) with live search and cross-linked definitions | Adding/editing terms; run `crosslink_glossary.py` *and* `crosslink_pages.py` after |
+| `glossary.html` | Cloud-security glossary (326 terms) with live search and cross-linked definitions | Adding/editing terms; run `crosslink_glossary.py` *and* `crosslink_pages.py` after |
 | `glossary.js` | Live search/filter for `glossary.html` | Changing search behavior |
 | `meetings.js` | Filters + auto-detected speaker filter for `meetings.html` | Adding new recurring speakers (`SPEAKERS` list) |
 | `sitemap.xml` | XML sitemap for search engines | **Don't edit** -- lastmod refreshed automatically |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The vendor-neutral curriculum, written by practitioners. The site nav has five g
 | 🕵️ [Detection Engineering](https://csoh.org/detection-engineering.html) | Sigma, ATT&CK Cloud Matrix, detection-as-code, SIEM/lake/XDR |
 | 🚨 [Incident Response & Forensics](https://csoh.org/incident-response.html) | IR lifecycle, EC2/EKS/Lambda evidence, memory forensics, runbooks |
 | 🎯 [Cloud Pentesting & Red Teaming](https://csoh.org/cloud-pentesting.html) | AWS/Azure/GCP attack paths, Pacu/ROADtools/BloodHound, MITRE ATT&CK Cloud |
-| 🚩 [CTF Challenges](https://csoh.org/ctfs.html) | 52+ hands-on cloud CTFs across AWS / Azure / GCP / Kubernetes / AI |
+| 🚩 [CTF Challenges](https://csoh.org/ctfs.html) | 53+ hands-on cloud CTFs across AWS / Azure / GCP / Kubernetes / AI |
 
 ### Careers
 


### PR DESCRIPTION
## What Changed

Weekly automated documentation review for 2026-09-11. Three high-confidence stale counts corrected in docs; remaining findings listed below for human review.

## Type of Change

- [x] Documentation

## Fixes applied

- **CONTRIBUTING.md:314** — Updated glossary term count `310 → 326` (verified by `grep -c '<dt' glossary.html`).
- **DEVELOPMENT.md:807** — Same stale count in the File Reference table: `310 → 326`.
- **README.md:87** — Updated CTF count in featured-pages table `52+ → 53+` to match the `<!--count:ctfs-->53<!--/count-->` marker in `ctfs.html`.
- **DEVELOPMENT.md:337** — Removed hardcoded file count (`3231`) per CLAUDE.md guidance ("Re-derive it, never cite it"); replaced with a note to re-derive the count.

## Needs human review

- **about.html** — `og:image` and `twitter:image` both reference `img/og/index.jpg`. No `img/og/about.jpg` exists. Every social share of the About page shows the homepage card. Fix: run `generate_og_images.py --pages about.html` and update both meta tags to point to `img/og/about.jpg`.

- **mentorship.html** — Same issue: `og:image` and `twitter:image` reference `img/og/index.jpg` and no `img/og/mentorship.jpg` exists.

- **news.html** — `og:updated_time`, the JSON-LD `dateModified`, and every `hasPart` `dateModified` are set to `2026-09-30T00:00:00Z` — 19 days in the future as of today. The auto-generation script should stamp these with the actual run timestamp rather than a fixed end-of-month value.

- **meetings.html** — "111 sessions" is hard-coded in the OG description, Twitter description, JSON-LD description, and `numberOfItems`. Not wrapped in a count marker. Confirm current count and decide whether to add `sync_counts.py` management for these fields.

- **meetings/2026-01-16.html** (and its card preview in meetings.html:1262) — AI-generated recap for the January 16, 2026 session references "upcoming RSA Conference 2024" (the section heading at line 308 reads "RSA Conference 2024 Planning Discussion"). In January 2026, RSA 2024 occurred 20 months prior; the group was likely discussing RSA 2026. Needs transcript check to confirm the right year.

- **ai-ml-security.html** — States a specific ranking for "Unbounded Consumption" in the OWASP LLM Top 10 2026 list. CLAUDE.md records a prior automated review that confidently mis-stated the same ranking. Verify against the canonical source: `curl -s https://api.github.com/repos/GenAI-Security-Project/GenAI-LLM-Top10/contents/2026/final | grep -o '"name": "LLM[^"]*"'`.

- **cloud-security-certifications.html** — States three specific certification changes as fact: AWS SCS-C02 → SCS-C03 (December 2025), ISC2 CCSP → CAT format (October 2025), and SC-400 → SC-401 retirement (May 2025). The page carries a general caveat to verify before booking, but if any date or version number is wrong it actively misinforms exam planners. Worth a spot-check against the respective certification body pages.

- **about-shawn-nunley.html** — JSON-LD `dateModified` is `2026-05-23` (~4 months ago). If the page has been edited since, update it; if not, it is correct.

- **security-policy.html:374** — Bullet reads "Add your name to a security researchers acknowledgments section (coming soon)." If this section has been planned but not yet created, it remains accurate; if it has been indefinitely deferred or dropped, the "(coming soon)" qualifier should be removed.

## Nothing-to-fix areas

The following areas were scanned and found clean:

- **Copyright year** — `&copy; 2023-2026` footer is correct across all pages checked.
- **Founding date** — "February 2023" appears consistently and is accurate.
- **"42 years in tech starting in 1984" bio** — math is correct for 2026 (1984 → 2026 = 42 years).
- **index.html** — All OG/Twitter/JSON-LD metadata present and internally consistent; no stale body content found.
- **sessions.html** — Metadata complete; body content is evergreen (Friday 7am PT, February 2023 origin, 2,000+ members).
- **faq.html** — JSON-LD FAQPage answers consistent with site-wide facts; newsletter-sponsor-retired note present.
- **community.html, contribute.html, topics.html** — No issues found.
- **conferences.html** — `numberOfItems: 26` consistent with listed items; `dateModified` plausible.
- **Nav/footer chrome** — Generated by `sync_chrome.py`; not manually reviewed page-by-page per CLAUDE.md guidance that it is idempotent and managed by tooling.

## Testing

- [x] Verified links work (internal file references for the changed counts were cross-checked against the actual source files)
- Changes are docs only (`.md` files); no HTML, CSS, or JS was modified.

## Notes

Review covered: all `.html` files at the root and in `breaches/`, `meetings/`, `homelab/`, `howto/`, `portfolio/` subdirectories (spot-checked), plus `README.md`, `CONTRIBUTING.md`, `DEVELOPMENT.md`, `SECURITY.md`, and `docs/EDITORIAL_STANDARDS.md` in full.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tJjMUQ28uac1LLVmfZdKz

---
_Generated by [Claude Code](https://claude.ai/code/session_016tJjMUQ28uac1LLVmfZdKz)_